### PR TITLE
Fix escaped html in twig templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![PHP Version](https://img.shields.io/badge/PHP-8.3-8892BF.svg?style=for-the-badge&logo=php)](https://www.php.net/)
 [![License](https://img.shields.io/badge/License-MIT-00ff00.svg?style=for-the-badge)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.2.0-00ffff.svg?style=for-the-badge)](CHANGES.md)
+[![Version](https://img.shields.io/badge/Version-3.2.2-00ffff.svg?style=for-the-badge)](CHANGES.md)
 
 </div>
 
@@ -131,6 +131,28 @@ SmartMoons-v3.0/
 ---
 
 ## 📖 Changelog
+
+### **v3.2.2** _(2025-10-01)_
+🔧 **Twig Template Fix: HTML Output Escaping**
+- ✅ **Fixed escaped HTML output in Twig templates** - Added `|raw` filter to system-controlled HTML variables
+- ✅ **Install templates fixed** - System requirements now display formatted (green/red) status indicators
+  - Fixed variables: `PHP`, `global`, `pdo`, `gdlib`, `json`, `iniset`, `dir`, `config`, `done`, `execscript`, `message`
+- ✅ **Game templates fixed** - Fleet events, news, and rank info now render HTML correctly
+  - Fixed variables: `fleet.text`, `rankInfo`, `news`, `execscript`
+- ✅ **Admin templates fixed** - JavaScript execution in admin panel headers
+  - Fixed variables: `execscript`
+- 🎯 **Installer fully functional** - All system check icons (✓/✗) now display correctly in `/install/index.php`
+- 🛡️ **Security maintained** - Only controlled system variables marked as raw, user input remains escaped
+- 📝 **Files modified**: 
+  - `styles/templates/install/ins_req.twig`
+  - `styles/templates/install/ins_header.twig`
+  - `styles/templates/install/ins_step4.twig`
+  - `styles/templates/game/page.overview.default.twig`
+  - `styles/templates/game/page.phalanx.default.twig`
+  - `styles/templates/game/page.alliance.home.twig`
+  - `styles/templates/game/main.header.twig`
+  - `styles/templates/adm/overall_header.twig`
+- 👤 **Changed by: 0wum0**
 
 ### **v3.2.0** _(2025-10-01)_
 🎉 **COMPLETE TWIG MIGRATION - ZERO SMARTY SYNTAX REMAINING**

--- a/styles/templates/adm/overall_header.twig
+++ b/styles/templates/adm/overall_header.twig
@@ -60,7 +60,7 @@
 	{% endfor %}
 	<script type="text/javascript">
 	$(function() {
-		{{ execscript }}
+		{{ execscript|raw }}
 	});
 	</script>
 </head>

--- a/styles/templates/game/main.header.twig
+++ b/styles/templates/game/main.header.twig
@@ -63,7 +63,7 @@
 	{% block script %}{% endblock %}
 	<script type="text/javascript">
 	$(function() {
-		{{ execscript }}
+		{{ execscript|raw }}
 	});
 	</script>
 </head>

--- a/styles/templates/game/page.alliance.home.twig
+++ b/styles/templates/game/page.alliance.home.twig
@@ -53,12 +53,12 @@
 					<tr>
 						<td colspan="2">{{ member }}</td>
 					</tr>
-					{% for index, fleet in events %}
-					<tr>
-						<td id="fleettime_{{ index }}" class="fleets" data-fleet-end-time="{{ fleet.returntime }}" data-fleet-time="{{ fleet.resttime }}">-</td>
-						<td colspan="2">{{ fleet.text }}</td>
-					</tr>
-					{% endfor %}
+				{% for index, fleet in events %}
+				<tr>
+					<td id="fleettime_{{ index }}" class="fleets" data-fleet-end-time="{{ fleet.returntime }}" data-fleet-time="{{ fleet.resttime }}">-</td>
+					<td colspan="2">{{ fleet.text|raw }}</td>
+				</tr>
+				{% endfor %}
 				{% endfor %}
 			{% else %}
 				<tr>

--- a/styles/templates/game/page.overview.default.twig
+++ b/styles/templates/game/page.overview.default.twig
@@ -18,7 +18,7 @@
 			{% for index, fleet in fleets %}
 			<tr>
 				<td id="fleettime_{{ index }}" class="fleets" data-fleet-end-time="{{ fleet.returntime }}" data-fleet-time="{{ fleet.resttime }}">{pretty_fly_time({{ fleet.resttime }})}</td>
-				<td colspan="2">{{ fleet.text }}</td>
+				<td colspan="2">{{ fleet.text|raw }}</td>
 			</tr>
 			{% endfor %}
 		</table>
@@ -52,10 +52,10 @@
 							<td class="desc">{{ LNG.ov_position }}</td>
 							<td class="data"><a href="game.php?page=galaxy&amp;galaxy={{ galaxy }}&amp;system={{ system }}">[{{ galaxy }}:{{ system }}:{{ planet }}]</a></td>
 						</tr>
-						<tr>
-							<td class="desc">{{ LNG.ov_points }}</td>
-							<td class="data">{{ rankInfo }}</td>
-						</tr>
+					<tr>
+						<td class="desc">{{ LNG.ov_points }}</td>
+						<td class="data">{{ rankInfo|raw }}</td>
+					</tr>
 					</tbody>
 				</table>
 			</div>
@@ -78,12 +78,12 @@
 			<div class="clear"></div>
 		</div>
 
-		{% if is_news %}
-		<div>
-			<div class="title">{{ LNG.ov_news }}</div>
-			<div>{{ news }}</div>
-		</div>
-		{% endif %}
+	{% if is_news %}
+	<div>
+		<div class="title">{{ LNG.ov_news }}</div>
+		<div>{{ news|raw }}</div>
+	</div>
+	{% endif %}
 
 		{% if ref_active %}
 		<div style="margin-top: 10px; text-align: center;">

--- a/styles/templates/game/page.phalanx.default.twig
+++ b/styles/templates/game/page.phalanx.default.twig
@@ -10,7 +10,7 @@
 	{% for index, fleet in fleetTable %}
 	<tr>
 		<td id="fleettime_{{ index }}" class="fleets" data-fleet-end-time="{{ fleet.returntime }}" data-fleet-time="{{ fleet.resttime }}">00:00:00</td>
-		<td>{{ fleet.text }}</td>
+		<td>{{ fleet.text|raw }}</td>
 	</tr>
 	{% else %}
 		<tr><td colspan="2">{{ LNG.px_no_fleet }}</td></tr>

--- a/styles/templates/install/ins_header.twig
+++ b/styles/templates/install/ins_header.twig
@@ -40,7 +40,7 @@
 	{% block script %}{% endblock %}
 	<script type="text/javascript">
 	$(function() {
-		{{ execscript }}
+		{{ execscript|raw }}
 	});
 	</script>
 </head>

--- a/styles/templates/install/ins_req.twig
+++ b/styles/templates/install/ins_req.twig
@@ -5,33 +5,33 @@
 			<h2>{{ LNG.req_head }}</h2>
 			<p>{{ LNG.req_desc }}</p>
 			<table class="req border">
-				<tr>
-					<td class="transparent left"><p>{{ LNG.req_php_need }}</p><p class="desc">{{ LNG.req_php_need_desc }}</p></td>
-					<td class="transparent">{{ PHP }}</td>
-				</tr>
-				<tr>
-					<td class="transparent left"><p>{{ LNG.reg_global_need }}</p><p class="desc">{{ LNG.reg_global_desc }}</p></td>
-					<td class="transparent">{{ global }}</th>
-				</tr>
-				<tr>
-					<td class="transparent left"><p>{{ LNG.reg_pdo_active }}</p><p class="desc">{{ LNG.reg_pdo_desc }}</p></td>
-					<td class="transparent">{{ pdo }}</th>
-				</tr>
-				<tr>
-					<td class="transparent left"><p>{{ LNG.reg_gd_need }}</p><p class="desc">{{ LNG.reg_gd_desc }}</p></td>
-					<td class="transparent">{{ gdlib }}</td>
-				</tr>
-				<tr>
-					<td class="transparent left"><p>{{ LNG.reg_json_need }}</p></td>
-					<td class="transparent">{{ json }}</td>
-				</tr>
-				<tr>
-					<td class="transparent left"><p>{{ LNG.reg_iniset_need }}</p></td>
-					<td class="transparent">{{ iniset }}</td>
-				</tr>
-				{{ dir }}
-				{{ config }}
-				{{ done }}
+			<tr>
+				<td class="transparent left"><p>{{ LNG.req_php_need }}</p><p class="desc">{{ LNG.req_php_need_desc }}</p></td>
+				<td class="transparent">{{ PHP|raw }}</td>
+			</tr>
+			<tr>
+				<td class="transparent left"><p>{{ LNG.reg_global_need }}</p><p class="desc">{{ LNG.reg_global_desc }}</p></td>
+				<td class="transparent">{{ global|raw }}</th>
+			</tr>
+			<tr>
+				<td class="transparent left"><p>{{ LNG.reg_pdo_active }}</p><p class="desc">{{ LNG.reg_pdo_desc }}</p></td>
+				<td class="transparent">{{ pdo|raw }}</th>
+			</tr>
+			<tr>
+				<td class="transparent left"><p>{{ LNG.reg_gd_need }}</p><p class="desc">{{ LNG.reg_gd_desc }}</p></td>
+				<td class="transparent">{{ gdlib|raw }}</td>
+			</tr>
+			<tr>
+				<td class="transparent left"><p>{{ LNG.reg_json_need }}</p></td>
+				<td class="transparent">{{ json|raw }}</td>
+			</tr>
+			<tr>
+				<td class="transparent left"><p>{{ LNG.reg_iniset_need }}</p></td>
+				<td class="transparent">{{ iniset|raw }}</td>
+			</tr>
+			{{ dir|raw }}
+			{{ config|raw }}
+			{{ done|raw }}
 			</table>
 		</div>
 	</td>

--- a/styles/templates/install/ins_step4.twig
+++ b/styles/templates/install/ins_step4.twig
@@ -3,7 +3,7 @@
 	<td colspan="2">
 		<div class="installcontent">
 			<div id="main" class="left">
-				<div class="{{ class }}"><p>{{ message }}</p></div>
+				<div class="{{ class }}"><p>{{ message|raw }}</p></div>
 				{% if class == 'noerror' %}
 				<div style="text-align:center;"><p>
 					<a href="index.php?mode=install&step=5"><button>{{ LNG.continue }}</button></a>


### PR DESCRIPTION
Corrected escaped HTML output in Twig templates by applying the `|raw` filter to system-controlled variables, ensuring correct rendering of status indicators, fleet events, and news.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9f30420-c040-483a-bc48-d7632e6b63a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9f30420-c040-483a-bc48-d7632e6b63a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

