### PR TITLE
Fix twig template syntax errors

### DIFF
--- a/check_twig_syntax.py
+++ b/check_twig_syntax.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Comprehensive Twig template syntax checker for SmartMoons
+Identifies common syntax errors from old Smarty conversions
+"""
+import os
+import re
+from pathlib import Path
+from typing import List, Dict, Tuple
+
+def check_twig_file(filepath: str) -> List[Dict]:
+    """Check a single Twig file for syntax errors"""
+    errors = []
+    
+    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read()
+        lines = content.split('\n')
+    
+    for line_num, line in enumerate(lines, 1):
+        # Check for triple closing braces: }}}
+        if '}}}' in line:
+            errors.append({
+                'file': filepath,
+                'line': line_num,
+                'type': 'triple_brace',
+                'content': line.strip(),
+                'issue': 'Triple closing brace }}}'
+            })
+        
+        # Check for space before closing braces in variables: {{ var } }}
+        if re.search(r'\{\{[^}]*\}\s+\}\}', line):
+            errors.append({
+                'file': filepath,
+                'line': line_num,
+                'type': 'space_before_close',
+                'content': line.strip(),
+                'issue': 'Space before closing }} in variable block'
+            })
+        
+        # Check for malformed variable blocks: {{ var }
+        if re.search(r'\{\{[^}]+\}(?!\})', line):
+            # Make sure it's not a valid {% block %}
+            if not re.search(r'\{%.*%\}', line):
+                errors.append({
+                    'file': filepath,
+                    'line': line_num,
+                    'type': 'single_close_var',
+                    'content': line.strip(),
+                    'issue': 'Single closing brace } after variable {{ - should be }}'
+                })
+        
+        # Check for space before %}: {% if x } %}
+        # But exclude valid cases like with {'key': 'value'} %}
+        if re.search(r'\{%\s+(?:if|for|set|elseif|elif)[^}]*\}\s+%\}', line):
+            # Double check it's not a valid 'with' statement
+            if not re.search(r'with\s+\{[^}]+\}\s+%\}', line):
+                errors.append({
+                    'file': filepath,
+                    'line': line_num,
+                    'type': 'space_before_percent',
+                    'content': line.strip(),
+                    'issue': 'Space before %} in logic block'
+                })
+        
+        # Check for unclosed variable blocks: {{ var
+        if re.search(r'\{\{[^}]*$', line) and not re.search(r'\}\}', line):
+            errors.append({
+                'file': filepath,
+                'line': line_num,
+                'type': 'unclosed_var',
+                'content': line.strip(),
+                'issue': 'Unclosed variable block {{'
+            })
+        
+        # Check for unclosed logic blocks: {% if
+        if re.search(r'\{%[^%]*$', line) and not re.search(r'%\}', line):
+            errors.append({
+                'file': filepath,
+                'line': line_num,
+                'type': 'unclosed_logic',
+                'content': line.strip(),
+                'issue': 'Unclosed logic block {%'
+            })
+    
+    # Check block balance
+    if_count = content.count('{% if ')
+    endif_count = content.count('{% endif %}')
+    if if_count != endif_count:
+        errors.append({
+            'file': filepath,
+            'line': 0,
+            'type': 'unbalanced_if',
+            'content': f'if: {if_count}, endif: {endif_count}',
+            'issue': f'Unbalanced if/endif blocks: {if_count} ifs vs {endif_count} endifs'
+        })
+    
+    for_count = content.count('{% for ')
+    endfor_count = content.count('{% endfor %}')
+    if for_count != endfor_count:
+        errors.append({
+            'file': filepath,
+            'line': 0,
+            'type': 'unbalanced_for',
+            'content': f'for: {for_count}, endfor: {endfor_count}',
+            'issue': f'Unbalanced for/endfor blocks: {for_count} fors vs {endfor_count} endfors'
+        })
+    
+    block_count = content.count('{% block ')
+    endblock_count = content.count('{% endblock %}')
+    if block_count != endblock_count:
+        errors.append({
+            'file': filepath,
+            'line': 0,
+            'type': 'unbalanced_block',
+            'content': f'block: {block_count}, endblock: {endblock_count}',
+            'issue': f'Unbalanced block/endblock: {block_count} blocks vs {endblock_count} endblocks'
+        })
+    
+    return errors
+
+def scan_templates(base_path: str) -> Dict:
+    """Scan all Twig templates in the given path"""
+    all_errors = []
+    files_checked = 0
+    
+    for root, dirs, files in os.walk(base_path):
+        for file in files:
+            if file.endswith('.twig'):
+                filepath = os.path.join(root, file)
+                files_checked += 1
+                errors = check_twig_file(filepath)
+                all_errors.extend(errors)
+    
+    return {
+        'files_checked': files_checked,
+        'errors': all_errors,
+        'error_count': len(all_errors)
+    }
+
+if __name__ == '__main__':
+    template_path = '/workspace/styles/templates'
+    
+    print(f"Scanning Twig templates in: {template_path}")
+    print("=" * 80)
+    
+    results = scan_templates(template_path)
+    
+    print(f"\nFiles checked: {results['files_checked']}")
+    print(f"Total errors found: {results['error_count']}")
+    print("=" * 80)
+    
+    if results['errors']:
+        print("\nERRORS FOUND:\n")
+        
+        # Group by file
+        errors_by_file = {}
+        for error in results['errors']:
+            file = error['file']
+            if file not in errors_by_file:
+                errors_by_file[file] = []
+            errors_by_file[file].append(error)
+        
+        for file, errors in sorted(errors_by_file.items()):
+            print(f"\n{file}")
+            print("-" * 80)
+            for error in errors:
+                if error['line'] > 0:
+                    print(f"  Line {error['line']}: {error['issue']}")
+                    print(f"    {error['content']}")
+                else:
+                    print(f"  File-level: {error['issue']}")
+                    print(f"    {error['content']}")
+        
+        print("\n" + "=" * 80)
+        print(f"Summary: {len(errors_by_file)} files with errors")
+    else:
+        print("\n✅ No syntax errors found! All templates appear to be valid.")

--- a/styles/templates/adm/overall_header.twig
+++ b/styles/templates/adm/overall_header.twig
@@ -64,5 +64,5 @@
 	});
 	</script>
 </head>
-<body id="{{ GET.page|default("overview")|escape}" class="{{ bodyclass }}">
+<body id="{{ GET.page|default("overview")|escape }}" class="{{ bodyclass }}">
 	<div id="tooltip" class="tip"></div>

--- a/styles/templates/game/main.navigation_header.twig
+++ b/styles/templates/game/main.navigation_header.twig
@@ -1,7 +1,7 @@
 <div id="main_header">
 	<div class="main_list_left">
 		<ul>
-			<li><a href="game.php?page=changelog" style="color: lime; font-weight: bold;">V{{ VERSION|replace:'.git':''}</a></li>
+			<li><a href="game.php?page=changelog" style="color: lime; font-weight: bold;">V{{ VERSION|replace({'.git':''}) }}</a></li>
 			<li><a href="game.php?page=overview"><i class="fas fa-home"></i></a></li>
 			{% if isModuleAvailable(constant('MODULE_IMPERIUM')) %}<li><a href="game.php?page=imperium"><i class="fas fa-globe"></i></a></li>{% endif %}
 			{% if isModuleAvailable(constant('MODULE_STATISTICS')) %}<li><a href="game.php?page=statistics"><i class="fas fa-chart-pie"></i></a></li>{% endif %}

--- a/styles/templates/game/page.alliance.admin.overview.twig
+++ b/styles/templates/game/page.alliance.admin.overview.twig
@@ -78,7 +78,7 @@
 			<tr>
 				<td>{{ LNG.al_view_events }}</td>
 				<td>
-					<select name="events[]" size="{{ available_events|@count}" multiple>
+					<select name="events[]" size="{{ available_events|length }}" multiple>
 						{% for id, mission in available_events %}
 							{% for selected_events in ally_events %}
 								{% if selected_events == id %}

--- a/styles/templates/game/page.alliance.info.twig
+++ b/styles/templates/game/page.alliance.info.twig
@@ -71,7 +71,7 @@
 			<th colspan="2">{{ LNG.pl_fightstats }}</th>
 		</tr>
 		<tr>
-			<td>{{ LNG.pl_totalfight }}</td><td>{{ statisticData.totalfight|number}</td>
+			<td>{{ LNG.pl_totalfight }}</td><td>{{ statisticData.totalfight|number }}</td>
 		</tr>
 		<tr>
 			<td>{{ LNG.pl_fightwon }}</td><td>{{ statisticData.fightwon|number}{% if statisticData.totalfight %} ({round(statisticData.fightwon / $statisticData.totalfight * 100, 2)}%){% endif %}</td>


### PR DESCRIPTION
Fix Twig template syntax errors to ensure proper rendering and compatibility, primarily correcting issues from old Smarty syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-24870206-53f0-4460-bbc8-76ab52435e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24870206-53f0-4460-bbc8-76ab52435e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

