### PR TITLE
Fix twig template syntax errors

### DIFF
--- a/styles/templates/adm/CronjobDetail.twig
+++ b/styles/templates/adm/CronjobDetail.twig
@@ -20,27 +20,27 @@
 <tr>
 	<td>{{ LNG.cronjob_min }}</td>
 	<td colspan=2><select style="height:100px;width:80px;" name="min[]" multiple="multiple">{% for item in range(0, 59) %}<option value="{{ item }}">{{ item }}</option>{% endfor %}</select><br>
-	<input name="min_all" id="min_all" type="checkbox" value="1" {% if min is defined.0 && min.0 == "*" %}checked{% endif %}><label for="min_all">{{ LNG.cronjob_selectall }}</label></td>
+	<input name="min_all" id="min_all" type="checkbox" value="1" {% if min[0] is defined and min.0 == "*" %}checked{% endif %}><label for="min_all">{{ LNG.cronjob_selectall }}</label></td>
 </tr>
 <tr>
 	<td>{{ LNG.cronjob_hours }}</td>
 	<td colspan=2><select style="height:100px;width:80px;" name="hours[]" multiple="multiple">{% for item in range(0, 23) %}<option value="{{ item }}">{{ item }}</option>{% endfor %}</select><br>
-	<input name="hours_all" id="hours_all" type="checkbox" value="1" {% if hours is defined.0 && hours.0 == "*" %}checked{% endif %}><label for="hours_all">{{ LNG.cronjob_selectall }}</label></td>
+	<input name="hours_all" id="hours_all" type="checkbox" value="1" {% if hours[0] is defined and hours.0 == "*" %}checked{% endif %}><label for="hours_all">{{ LNG.cronjob_selectall }}</label></td>
 </tr>
 <tr>
 	<td>{{ LNG.cronjob_dom }}</td>
 	<td colspan=2><select style="height:100px;width:80px;" name="dom[]" multiple="multiple">{% for item in range(1, 31) %}<option value="{{ item }}">{{ item }}</option>{% endfor %}</select><br>
-	<input name="dom_all" id="dom_all" type="checkbox" value="1" {% if dom is defined.0 && dom.0 == "*" %}checked{% endif %}><label for="dom_all">{{ LNG.cronjob_selectall }}</label></td>
+	<input name="dom_all" id="dom_all" type="checkbox" value="1" {% if dom[0] is defined and dom.0 == "*" %}checked{% endif %}><label for="dom_all">{{ LNG.cronjob_selectall }}</label></td>
 </tr>
 <tr>
 	<td>{{ LNG.cronjob_month }}</td>
 	<td colspan=2><select style="height:100px;width:80px;" name="month[]" multiple="multiple">{% for item in range(0, 60) %}<option value="{{ item }}">{{ item }}</option>{% endfor %}</select><br>
-	<input name="month_all" id="month_all" type="checkbox" value="1" {% if month is defined.0 && month.0 == "*" %}checked{% endif %}><label for="month_all">{{ LNG.cronjob_selectall }}</label></td>
+	<input name="month_all" id="month_all" type="checkbox" value="1" {% if month[0] is defined and month.0 == "*" %}checked{% endif %}><label for="month_all">{{ LNG.cronjob_selectall }}</label></td>
 </tr>
 <tr>
 	<td>{{ LNG.cronjob_dow }}</td>
 	<td colspan=2><select style="height:100px;width:80px;" name="dow[]" multiple="multiple">{% for item in range(0, 60) %}<option value="{{ item }}">{{ item }}</option>{% endfor %}</select><br>
-	<input name="dow_all" id="dow_all" type="checkbox" value="1" {% if dow is defined.0 && dow.0 == "*" %}checked{% endif %}><label for="dow_all">{{ LNG.cronjob_selectall }}</label></td>
+	<input name="dow_all" id="dow_all" type="checkbox" value="1" {% if dow[0] is defined and dow.0 == "*" %}checked{% endif %}><label for="dow_all">{{ LNG.cronjob_selectall }}</label></td>
 </tr>
 <tr>
 	<td>{{ LNG.cronjob_class }}</td>

--- a/styles/templates/adm/FacebookPage.twig
+++ b/styles/templates/adm/FacebookPage.twig
@@ -10,7 +10,7 @@
 	<td colspan="2">{{ fb_curl_info }}</td>
 </tr><tr>
 	<td>{{ fb_active }}</td>
-	<td><input name="fb_on"{% if fb_on == 1 && fb_curl == 1 %} checked="checked"{% endif %} type="checkbox"{% if fb_curl == 0 %} disabled{% endif %}></td>
+	<td><input name="fb_on"{% if fb_on == 1 and fb_curl == 1 %} checked="checked"{% endif %} type="checkbox"{% if fb_curl == 0 %} disabled{% endif %}></td>
 </tr><tr>
 	<td>{{ fb_api_key }}</td>
 	<td><input name="fb_apikey" size="40" value="{{ fb_apikey }}" type="text"{% if fb_curl == 0 %} disabled{% endif %}></td>

--- a/styles/templates/adm/MessageList.twig
+++ b/styles/templates/adm/MessageList.twig
@@ -42,7 +42,7 @@
 	{% for messageID, messageRow in messageList %}
 	<tr data-messageID="{{ messageID }}">
 		<td><a href="#" class="toggle">{{ messageID }}</a></td>
-		{% if Selected == 100 %}<td><a href="#" class="toggle">{{ LNG.mg_type[$messageRow.type] }}</a></td>{% endif %}
+		{% if Selected == 100 %}<td><a href="#" class="toggle">{{ LNG.mg_type[messageRow.type] }}</a></td>{% endif %}
 		<td><a href="#" class="toggle">{{ messageRow.time }}</a></td>
 		<td><a href="#" class="toggle">{{ messageRow.sender }}</a></td>
 		<td><a href="#" class="toggle">{{ messageRow.receiver }}</a></td>

--- a/styles/templates/adm/page.ticket.view.twig
+++ b/styles/templates/adm/page.ticket.view.twig
@@ -19,7 +19,7 @@
 			{% endif %}
 			{% if loop.first %}
 			{{ LNG.ti_create }}: <b>{{ answerRow.time }}</b> {{ LNG.ti_from }} <b>{{ answerRow.ownerName }}</b>
-				<br>{{ LNG.ti_category }}: {{ categoryList[$answerRow.categoryID] }}
+				<br>{{ LNG.ti_category }}: {{ categoryList[answerRow.categoryID] }}
 			{% endif %}
 			</p>
 			<hr>

--- a/styles/templates/game/main.navigation.twig
+++ b/styles/templates/game/main.navigation.twig
@@ -8,7 +8,7 @@
 		{% if isModuleAvailable(constant('MODULE_RESEARCH')) %}<a href="game.php?page=research">{{ LNG.lm_research }}</a>{% endif %}
 		{% if isModuleAvailable(constant('MODULE_SHIPYARD_FLEET')) %}<a href="game.php?page=shipyard&amp;mode=fleet">{{ LNG.lm_shipshard }}</a>{% endif %}
 		{% if isModuleAvailable(constant('MODULE_SHIPYARD_DEFENSIVE')) %}<a href="game.php?page=shipyard&amp;mode=defense">{{ LNG.lm_defenses }}</a>{% endif %}
-		{% if isModuleAvailable(constant('MODULE_OFFICIER')) || isModuleAvailable(constant('MODULE_DMEXTRAS')) %}<a href="game.php?page=officier">{{ LNG.lm_officiers }}</a>{% endif %}
+		{% if isModuleAvailable(constant('MODULE_OFFICIER')) or isModuleAvailable(constant('MODULE_DMEXTRAS')) %}<a href="game.php?page=officier">{{ LNG.lm_officiers }}</a>{% endif %}
 		{% if isModuleAvailable(constant('MODULE_FLEET_TRADER')) %}<a href="game.php?page=fleetDealer">{{ LNG.lm_fleettrader }}</a>{% endif %}
 		{% if isModuleAvailable(constant('MODULE_TRADER')) %}<a href="game.php?page=fleetTable">{{ LNG.lm_fleet }}</a>{% endif %}
 		{% if isModuleAvailable(constant('MODULE_RESSOURCE_LIST')) %}<a href="game.php?page=resources">{{ LNG.lm_resources }}</a>{% endif %}

--- a/styles/templates/game/main.topnav.twig
+++ b/styles/templates/game/main.topnav.twig
@@ -10,7 +10,7 @@
 	        <div class="bar-text">
 		        {% if shortlyNumber %}
 					{% if resourceData.current is not defined %}
-					{{ resourceData.current = resourceData.max + $resourceData.used }}
+					{{ resourceData.current = resourceData.max + resourceData.used }}
 						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ shortly_number(resourceData.current) }}&nbsp;/&nbsp;{{ shortly_number(resourceData.max) }}</span></span>
 					{% else %}
 						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
@@ -20,7 +20,7 @@
 					{% endif %}
 		        {% else %}
 					{% if resourceData.current is not defined %}
-					{{ resourceData.current = resourceData.max + $resourceData.used }}
+					{{ resourceData.current = resourceData.max + resourceData.used }}
 						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}</span></span>
 					{% else %}
 						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
@@ -31,7 +31,7 @@
 		        {% endif %}
 	        </div>
 	      </div>
-	      {% if resourceID != 911 && resourceID != 921 %}
+	      {% if resourceID != 911 and resourceID != 921 %}
 	      {% if isModuleAvailable(constant('MODULE_TRADER')) %}
 	      <div class="bar-change">
 	      	<a href="game.php?page=trader&mode=trade&resource={{ resourceID }}"><i class="fas fa-arrows-alt-h"></i></a>
@@ -52,7 +52,7 @@
 	{% endfor %}
 	<div class="clear"></div>
 
-		{% if !vmode %}
+		{% if not vmode %}
 		<script type="text/javascript">
 		var viewShortlyNumber	= {{ shortlyNumber|json_encode }};
 		var vacation			= {{ vmode }};

--- a/styles/templates/game/page.alliance.admin.members.twig
+++ b/styles/templates/game/page.alliance.admin.members.twig
@@ -34,11 +34,11 @@
                                 <i class="far fa-envelope" title="{{ LNG.write_message }}" style="font-size: 15px;"></i>
                             </a>
                         </td>
-                        <td>{% if memberListRow.rankID == -1 %}{{ founder }}{% elseif rankSelectList %}<!-- TODO: Complex html_options - needs manual review -->}]" options= rankSelectList selected= memberListRow.rankID}{% else %}{{ rankList[$memberListRow.rankID] }}{% endif %}</td>
+                        <td>{% if memberListRow.rankID == -1 %}{{ founder }}{% elseif rankSelectList %}<!-- TODO: Complex html_options - needs manual review -->{% else %}{{ rankList[memberListRow.rankID] }}{% endif %}</td>
                         <td><span title="{{ memberListRow.points|number_format }}">{{ shortly_number(memberListRow.points) }}</span></td>
                         <td><a href="game.php?page=galaxy&amp;galaxy={{ memberListRow.galaxy }}&amp;system={{ memberListRow.system }}">[{{ memberListRow.galaxy }}:{{ memberListRow.system }}:{{ memberListRow.planet }}]</a></td>
                         <td>{{ memberListRow.register_time }}</td>
-                        <td>{% if rights.ONLINESTATE %}{% if memberListRow.onlinetime < 4 %}<span style="color:lime">{{ LNG.al_memberlist_on }}</span>{% elseif memberListRow.onlinetime >= 4 && memberListRow.onlinetime <= 15 %}<span style="color:yellow">{{ memberListRow.onlinetime }} {{ LNG.al_memberlist_min }}</span>{% else %}<span style="color:red">{{ LNG.al_memberlist_off }}</span>{% endif %}{% else %}-{% endif %}</td>
+                        <td>{% if rights.ONLINESTATE %}{% if memberListRow.onlinetime < 4 %}<span style="color:lime">{{ LNG.al_memberlist_on }}</span>{% elseif memberListRow.onlinetime >= 4 and memberListRow.onlinetime <= 15 %}<span style="color:yellow">{{ memberListRow.onlinetime }} {{ LNG.al_memberlist_min }}</span>{% else %}<span style="color:red">{{ LNG.al_memberlist_off }}</span>{% endif %}{% else %}-{% endif %}</td>
                         <td>{% if memberListRow.rankID != -1 %}
                                 {% if canKick %}<a href="game.php?page=alliance&amp;mode=admin&amp;action=membersKick&amp;id={{ userID }}" onclick="return confirm('{{ memberListRow.kickQuestion }}');" style="border: 1px solid #212121;vertical-align:top;width:16px;height:16px;display:inline-block;margin:2px;"><img src="{{ dpath }}pic/abort.gif" border="0" alt=""></a>{% endif %}{% else %}-{% endif %}
                         </td>

--- a/styles/templates/game/page.alliance.admin.permissions.twig
+++ b/styles/templates/game/page.alliance.admin.permissions.twig
@@ -25,7 +25,7 @@
 				<td><a href="game.php?page=alliance&amp;mode=admin&amp;action=permissionsSend&amp;deleteRank={{ rowId }}"><img src="styles/resource/images/alliance/CLOSE.png" alt="" width="16" height="16"></a></td>
 				<td><input type="text" name="rank[{{ rowId }}][rankName]" value="{{ rankRow.rankName }}"></td>
 				{% for rankId, rankName in availableRanks %}
-				<td><input type="checkbox" name="rank[{{ rowId }}][{{ rankId }}]" value="1"{% if rankRow[rankName] %} checked{% endif %}{% if !ownRights[rankName] %} disabled{% endif %}></td>
+				<td><input type="checkbox" name="rank[{{ rowId }}][{{ rankId }}]" value="1"{% if rankRow[rankName] %} checked{% endif %}{% if not ownRights[rankName] %} disabled{% endif %}></td>
 				{% endfor %}
 			</tr>
 			{% else %}

--- a/styles/templates/game/page.alliance.home.twig
+++ b/styles/templates/game/page.alliance.home.twig
@@ -36,7 +36,7 @@
 			<td colspan="2"><a href="#" onclick="return Dialog.AllianceChat();">{{ LNG.al_goto_chat }}</a></td>
 		</tr>
 	    {% endif %}
-		{% if rights.SEEAPPLY && applyCount > 0 %}		
+		{% if rights.SEEAPPLY and applyCount > 0 %}		
 		<tr>
 			<td>{{ LNG.al_requests }}</td><td><a href="?page=alliance&amp;mode=admin&amp;action=mangeApply">{{ requests }}</a></td>
 		</tr>
@@ -106,13 +106,13 @@
 			<td>{{ LNG.pl_totalfight }}</td><td>{{ totalfight|number_format }}</td>
 		</tr>
 		<tr>
-			<td>{{ LNG.pl_fightwon }}</td><td>{{ fightwon|number_format }} {% if totalfight %}({{ round(fightwon / $totalfight * 100, 2) }}%){% endif %}</td>
+			<td>{{ LNG.pl_fightwon }}</td><td>{{ fightwon|number_format }} {% if totalfight %}({{ round(fightwon / totalfight * 100, 2) }}%){% endif %}</td>
 		</tr>
 		<tr>	
-			<td>{{ LNG.pl_fightlose }}</td><td>{{ fightlose|number_format }} {% if totalfight %}({{ round(fightlose / $totalfight * 100, 2) }}%){% endif %}</td>
+			<td>{{ LNG.pl_fightlose }}</td><td>{{ fightlose|number_format }} {% if totalfight %}({{ round(fightlose / totalfight * 100, 2) }}%){% endif %}</td>
 		</tr>
 		<tr>	
-			<td>{{ LNG.pl_fightdraw }}</td><td>{{ fightdraw|number_format }} {% if totalfight %}({{ round(fightdraw / $totalfight * 100, 2) }}%){% endif %}</td>
+			<td>{{ LNG.pl_fightdraw }}</td><td>{{ fightdraw|number_format }} {% if totalfight %}({{ round(fightdraw / totalfight * 100, 2) }}%){% endif %}</td>
 		</tr>
 		<tr>
 			<td>{{ LNG.pl_unitsshot }}</td><td>{{ unitsshot }}</td>
@@ -127,7 +127,7 @@
 			<td>{{ LNG.pl_dercrystal }}</td><td>{{ dercrystal }}</td>
 		</tr>
 	</table>
-	{% if !isOwner %}
+	{% if not isOwner %}
 	<table style="width: 100%;">
 		<tr>
 			<th>{{ LNG.al_leave_alliance }}</th>

--- a/styles/templates/game/page.buddyList.default.twig
+++ b/styles/templates/game/page.buddyList.default.twig
@@ -68,7 +68,7 @@
 				<td>
 				{% if myBuddyRow.onlinetime < 4 %}
 				<span style="color:lime">{{ LNG.bu_connected }}</span>
-				{% elseif myBuddyRow.onlinetime >= 4 && myBuddyRow.onlinetime <= 15 %}
+				{% elseif myBuddyRow.onlinetime >= 4 and myBuddyRow.onlinetime <= 15 %}
 				<span style="color:yellow">{{ myBuddyRow.onlinetime }} {{ LNG.bu_minutes }}</span>
 				{% else %}
 				<span style="color:red">{{ LNG.bu_disconnected }}</span>

--- a/styles/templates/game/page.buildings.default.twig
+++ b/styles/templates/game/page.buildings.default.twig
@@ -16,7 +16,7 @@
 			<tr>
 				<td style="width:70%;vertical-align:top;" class="left">
 					{{ loop.index }}.: 
-					{% if !(isBusy.research && (ID == 6 || ID == 31)) && !(isBusy.shipyard && (ID == 15 || ID == 21)) && RoomIsOk && CanBuildElement && BuildInfoList[ID].buyable %}
+					{% if !(isBusy.research and (ID == 6 or ID == 31)) and !(isBusy.shipyard and (ID == 15 or ID == 21)) and RoomIsOk and CanBuildElement and BuildInfoList[ID].buyable %}
 					<form class="build_form" action="game.php?page=buildings" method="post">
 						<input type="hidden" name="cmd" value="insert">
 						<input type="hidden" name="building" value="{{ ID }}">
@@ -58,7 +58,7 @@
 				<span style="float: right;">
 					{% if Element.level > 0 %}
 							{% if ID == 43 %}<a href="#" onclick="return Dialog.info({{ ID }})">{{ LNG.bd_jump_gate_action }}</a>{% endif %}
-							{% if (ID == 44 && !HaveMissiles) ||  ID != 44 %}<a class="tooltip_sticky" data-tooltip-content="
+							{% if (ID == 44 and not HaveMissiles) or ID != 44 %}<a class="tooltip_sticky" data-tooltip-content="
 								{#  Start Destruction Popup  #}
 								<table style='width:300px'>
 									<tr>
@@ -113,13 +113,13 @@
 						<div class="construct_button_lost">
 							<span style="color:red">{{ LNG.bd_maxlevel }}</span>
 						</div>
-					{% elseif (isBusy.research && (ID == 6 || ID == 31)) || (isBusy.shipyard && (ID == 15 || ID == 21)) %}
+					{% elseif (isBusy.research and (ID == 6 or ID == 31)) or (isBusy.shipyard and (ID == 15 or ID == 21)) %}
 						<div class="construct_button_lost">
 							<span style="color:red">{{ LNG.bd_working }}</span>
 						</div>
 					{% else %}
 						{% if RoomIsOk %}
-							{% if CanBuildElement && Element.buyable %}
+							{% if CanBuildElement and Element.buyable %}
 							<form action="game.php?page=buildings" method="post" class="build_form">
 								<input type="hidden" name="cmd" value="insert">
 								<input type="hidden" name="building" value="{{ ID }}">

--- a/styles/templates/game/page.fleetStep1.default.twig
+++ b/styles/templates/game/page.fleetStep1.default.twig
@@ -84,7 +84,7 @@
 						</select>
 					</div>
 				</td>
-				{% if loop.last && (loop.index % themeSettings.SHORTCUT_ROWS_ON_FLEET1) != 0 %}
+				{% if loop.last and (loop.index % themeSettings.SHORTCUT_ROWS_ON_FLEET1) != 0 %}
 				{% set to = themeSettings.SHORTCUT_ROWS_ON_FLEET1 - (loop.index % themeSettings.SHORTCUT_ROWS_ON_FLEET1) %}
 				{% for foo in range(1, to + 1) %}
 				<td class="shortcut-colum" style="width:{{ 100 / themeSettings.SHORTCUT_ROWS_ON_FLEET1 }}%">&nbsp;</td>
@@ -129,7 +129,7 @@
 			<td>
 				<a href="javascript:setTarget({{ ColonyRow.galaxy }},{{ ColonyRow.system }},{{ ColonyRow.planet }},{{ ColonyRow.type }});updateVars();">{{ ColonyRow.name }}{% if ColonyRow.type == 3 %}{{ LNG.fl_moon_shortcut }}{% endif %} [{{ ColonyRow.galaxy }}:{{ ColonyRow.system }}:{{ ColonyRow.planet }}]</a>
 			</td>
-			{% if loop.last && (loop.index % themeSettings.COLONY_ROWS_ON_FLEET1) != 0 %}
+			{% if loop.last and (loop.index % themeSettings.COLONY_ROWS_ON_FLEET1) != 0 %}
 			{% set to = themeSettings.COLONY_ROWS_ON_FLEET1 - (loop.index % themeSettings.COLONY_ROWS_ON_FLEET1) %}
 			{% for foo in range(1, to + 1) %}<td>&nbsp;</td>{% endfor %}
 			{% endif %}
@@ -150,7 +150,7 @@
 			<tr style="height:20px;">
 				<td><a href="javascript:setACSTarget({{ ACSRow.galaxy }},{{ ACSRow.system }},{{ ACSRow.planet }},{{ ACSRow.planet_type }},{{ ACSRow.id }});">{{ ACSRow.name }} - [{{ ACSRow.galaxy }}:{{ ACSRow.system }}:{{ ACSRow.planet }}]</a></td>
 			</tr>
-			{% if loop.last && (loop.index % themeSettings.ACS_ROWS_ON_FLEET1) != 0 %}
+			{% if loop.last and (loop.index % themeSettings.ACS_ROWS_ON_FLEET1) != 0 %}
 			{% set to = themeSettings.ACS_ROWS_ON_FLEET1 - (loop.index % themeSettings.ACS_ROWS_ON_FLEET1) %}
 			{% for foo in range(1, to + 1) %}<td>&nbsp;</td>{% endfor %}
 			{% endif %}

--- a/styles/templates/game/page.fleetTable.default.twig
+++ b/styles/templates/game/page.fleetTable.default.twig
@@ -39,14 +39,14 @@
 			<td><a href="game.php?page=galaxy&amp;galaxy={{ FlyingFleetRow.startGalaxy }}&amp;system={{ FlyingFleetRow.startSystem }}">[{{ FlyingFleetRow.startGalaxy }}:{{ FlyingFleetRow.startSystem }}:{{ FlyingFleetRow.startPlanet }}]</a></td>
 			<td{% if FlyingFleetRow.state == 0 %} style="color:lime"{% endif %}>{{ FlyingFleetRow.startTime }}</td>
 			<td><a href="game.php?page=galaxy&amp;galaxy={{ FlyingFleetRow.endGalaxy }}&amp;system={{ FlyingFleetRow.endSystem }}">[{{ FlyingFleetRow.endGalaxy }}:{{ FlyingFleetRow.endSystem }}:{{ FlyingFleetRow.endPlanet }}]</a></td>
-			{% if FlyingFleetRow.mission == 4 && FlyingFleetRow.state == 0 %}
+			{% if FlyingFleetRow.mission == 4 and FlyingFleetRow.state == 0 %}
 			<td>-</td>
 			{% else %}
 			<td{% if FlyingFleetRow.state != 0 %} style="color:lime"{% endif %}>{{ FlyingFleetRow.endTime }}</td>
 			{% endif %}
 			<td id="fleettime_{{ loop.index }}" class="fleets" data-fleet-end-time="{{ FlyingFleetRow.returntime }}" data-fleet-time="{{ FlyingFleetRow.resttime }}">{pretty_fly_time({{ FlyingFleetRow.resttime }})}</td>
 			<td>
-			{% if !isVacation && FlyingFleetRow.state != 1 %}
+			{% if not isVacation and FlyingFleetRow.state != 1 %}
 				<form action="game.php?page=fleetTable&amp;action=sendfleetback" method="post">
 				<input name="fleetID" value="{{ FlyingFleetRow.id }}" type="hidden">
 				<input value="{{ LNG.fl_send_back }}" type="submit">

--- a/styles/templates/game/page.information.default.twig
+++ b/styles/templates/game/page.information.default.twig
@@ -15,7 +15,7 @@
 				<td>
 					<table>
 						<tr>
-							<td class="transparent" style="width:120px"><img width="120" height="120" src="{{ dpath }}gebaeude/{{ elementID }}.{% if elementID >=600 && elementID <= 699 %}jpg{% else %}gif{% endif %}" alt=""></td>
+							<td class="transparent" style="width:120px"><img width="120" height="120" src="{{ dpath }}gebaeude/{{ elementID }}.{% if elementID >=600 and elementID <= 699 %}jpg{% else %}gif{% endif %}" alt=""></td>
 							<td class="transparent left"><p>{{ LNG.longDescription[elementID] }}</p>
 							{% if Bonus %}<p>
 							<b>{{ LNG.in_bonus }}</b><br>

--- a/styles/templates/game/page.messages.default.twig
+++ b/styles/templates/game/page.messages.default.twig
@@ -12,11 +12,11 @@
 		<table style="width:100%;table-layout:fixed;">
 				{% for CategoryID, CategoryRow in CategoryList %}
 				{% if (loop.index % 6) == 1 %}<tr>{% endif %}
-				{% if loop.last && (loop.index % 6) != 0 %}<td>&nbsp;</td>{% endif %}
+				{% if loop.last and (loop.index % 6) != 0 %}<td>&nbsp;</td>{% endif %}
 				<td style="word-wrap: break-word;color:{{ CategoryRow.color }};"><a href="#" onclick="Message.getMessages({{ CategoryID }});return false;" style="color:{{ CategoryRow.color }};">{{ LNG.mg_type[CategoryID] }}</a>
 				<br><span id="unread_{{ CategoryID }}">{{ CategoryRow.unread }}</span>/<span id="total_{{ CategoryID }}">{{ CategoryRow.total }}</span>
 				</td>
-				{% if loop.last || (loop.index % 6) == 0 %}</tr>{% endif %}
+				{% if loop.last or (loop.index % 6) == 0 %}</tr>{% endif %}
 				{% endfor %}
 		</table>
 	</div>

--- a/styles/templates/game/page.messages.view.twig
+++ b/styles/templates/game/page.messages.view.twig
@@ -38,14 +38,14 @@
 		<td>{{ LNG.mg_subject }}</td>
 	</tr>
 	{% for Message in MessageList %}
-	<tr id="message_{{ Message.id }}" class="title message_head{% if MessID != 999 && Message.unread == 1 %} mes_unread{% endif %}">
+	<tr id="message_{{ Message.id }}" class="title message_head{% if MessID != 999 and Message.unread == 1 %} mes_unread{% endif %}">
 		<td style="width:40px;" rowspan="2">
 		{% if MessID != 999 %}<input name="messageID[{{ Message.id }}]" value="1" type="checkbox">{% endif %}
 		</td>
 		<td>{{ Message.time }}</td>
 		<td>{{ Message.from }}</td>
 		<td>{{ Message.subject }}
-		{% if Message.type == 1 && MessID != 999 %}
+		{% if Message.type == 1 and MessID != 999 %}
 		<a href="#" onclick="return Dialog.PM({{ Message.sender }}, Message.CreateAnswer('{{ Message.subject }}'));" title="{{ LNG.mg_answer_to }} {{ strip_tags(Message.from) }}"><i class="far fa-envelope" title="Message privé" style="font-size: 15px;"></i></a>
 		{% endif %}
 		</td>

--- a/styles/templates/game/page.officier.default.twig
+++ b/styles/templates/game/page.officier.default.twig
@@ -26,7 +26,7 @@
 						{% endfor %}
 
 						<div style="margin-bottom: 10px;">
-							{% for BonusName, Bonus in Element.elementBonus %}{% if loop.index % 3 == 1 %}<p>{% endif %}{% if Bonus[0] < 0 %}-{% else %}+{% endif %}{% if Bonus[1] == 0 %}{{ abs(Bonus[0] * 100) }}%{% else %}{{ Bonus[0] }}{% endif %} {{ LNG.bonus[BonusName] }}{% if loop.index % 3 == 0 || loop.last %}</p>{% else %}&nbsp;{% endif %}{% endfor %}
+							{% for BonusName, Bonus in Element.elementBonus %}{% if loop.index % 3 == 1 %}<p>{% endif %}{% if Bonus[0] < 0 %}-{% else %}+{% endif %}{% if Bonus[1] == 0 %}{{ abs(Bonus[0] * 100) }}%{% else %}{{ Bonus[0] }}{% endif %} {{ LNG.bonus[BonusName] }}{% if loop.index % 3 == 0 or loop.last %}</p>{% else %}&nbsp;{% endif %}{% endfor %}
 						</div>
 
 						{% if Element.timeLeft > 0 %}
@@ -87,7 +87,7 @@
 						{% endfor %}
 
 						<div style="margin-bottom: 10px;">
-							{% for BonusName, Bonus in Element.elementBonus %}{% if loop.index % 3 == 1 %}<p>{% endif %}{% if Bonus[0] < 0 %}-{% else %}+{% endif %}{% if Bonus[1] == 0 %}{{ abs(Bonus[0] * 100) }}%{% else %}{{ Bonus[0] }}{% endif %} {{ LNG.bonus[BonusName] }}{% if loop.index % 3 == 0 || loop.last %}</p>{% else %}&nbsp;{% endif %}{% endfor %}
+							{% for BonusName, Bonus in Element.elementBonus %}{% if loop.index % 3 == 1 %}<p>{% endif %}{% if Bonus[0] < 0 %}-{% else %}+{% endif %}{% if Bonus[1] == 0 %}{{ abs(Bonus[0] * 100) }}%{% else %}{{ Bonus[0] }}{% endif %} {{ LNG.bonus[BonusName] }}{% if loop.index % 3 == 0 or loop.last %}</p>{% else %}&nbsp;{% endif %}{% endfor %}
 						</div>
 
 					</div>

--- a/styles/templates/game/page.research.default.twig
+++ b/styles/templates/game/page.research.default.twig
@@ -20,10 +20,10 @@
 			<tr>
 				<td style="width:70%;vertical-align:top;" class="left">
 					{% if ResearchList[List.element] is defined %}
-					{% set CQueue = ResearchList[$List.element] %}
+					{% set CQueue = ResearchList[List.element] %}
 					{% endif %}
 					{{ loop.index }}.: 
-					{% if CQueue is defined && CQueue.maxLevel != CQueue.level && !IsFullQueue && CQueue.buyable %}
+					{% if CQueue is defined and CQueue.maxLevel != CQueue.level and not IsFullQueue and CQueue.buyable %}
 					<form action="game.php?page=research" method="post" class="build_form">
 						<input type="hidden" name="cmd" value="insert">
 						<input type="hidden" name="tech" value="{{ ID }}">
@@ -83,7 +83,7 @@
 						<div class="construct_button_lost">
 							<span style="color:red">{{ LNG.bd_maxlevel }}</span>
 						</div>
-					{% elseif IsLabinBuild || IsFullQueue || !Element.buyable %}
+					{% elseif IsLabinBuild or IsFullQueue or not Element.buyable %}
 						<div class="construct_button_lost">
 							<span style="color:red">{% if Element.level == 0 %}{{ LNG.bd_tech }}{% else %}{{ LNG.bd_tech_next_level }}{{ Element.levelToBuild + 1 }}{% endif %}</span>
 						</div>

--- a/styles/templates/game/page.shipyard.default.twig
+++ b/styles/templates/game/page.shipyard.default.twig
@@ -8,7 +8,7 @@
 		{% if mode == "defense" %}{{ LNG.lm_defenses }}{% else %}{{ LNG.lm_shipshard }}{% endif %}
 	</div>
 
-	{% if !NotBuilding %}
+	{% if not NotBuilding %}
 		<div width="99%" id="infobox" style="border: 2px solid red; text-align:center;background:transparent">{{ LNG.bd_building_shipyard }}</div>
 	{% endif %}
 
@@ -62,7 +62,7 @@
 				</div>
 
 				<div>
-					{% if Element.AlreadyBuild %}<span style="color:red">{{ LNG.bd_protection_shield_only_one }}</span>{% elseif NotBuilding && Element.buyable %}<input style="width: 90%;" type="text" name="fmenge[{{ ID }}]" id="input_{{ ID }}" value="0" tabindex="{{ loop.index }}">
+					{% if Element.AlreadyBuild %}<span style="color:red">{{ LNG.bd_protection_shield_only_one }}</span>{% elseif NotBuilding and Element.buyable %}<input style="width: 90%;" type="text" name="fmenge[{{ ID }}]" id="input_{{ ID }}" value="0" tabindex="{{ loop.index }}">
 					<input style="padding: 8px; margin-left: -10px; border-left: none;" type="button" value="{{ LNG.bd_max_ships }}" onclick="$('#input_{{ ID }}').val('{{ Element.maxBuildable }}')"></p>
 					{% endif %}
 				</div>

--- a/styles/templates/game/page.techTree.default.twig
+++ b/styles/templates/game/page.techTree.default.twig
@@ -18,7 +18,7 @@
 			</tr>
 			{% else %}
 			<tr>
-				<td><a href="#" onclick="return Dialog.info({{ elementID }})"><img src="{{ dpath }}gebaeude/{{ elementID }}.{% if elementID >=600 && elementID <= 699 %}jpg{% else %}gif{% endif %}" width="50" height="50"></a></td>
+				<td><a href="#" onclick="return Dialog.info({{ elementID }})"><img src="{{ dpath }}gebaeude/{{ elementID }}.{% if elementID >=600 and elementID <= 699 %}jpg{% else %}gif{% endif %}" width="50" height="50"></a></td>
 				<td><a href="#" onclick="return Dialog.info({{ elementID }})">{{ LNG.tech[elementID] }}</a></td>
 				<td>
 				{% if requireList %}

--- a/styles/templates/game/page.ticket.view.twig
+++ b/styles/templates/game/page.ticket.view.twig
@@ -21,7 +21,7 @@
 				<td class="left" colspan="2">
 					{{ LNG.ti_msgtime }} <b>{{ answerRow.time }}</b> {{ LNG.ti_from }} <b>{{ answerRow.ownerName }}</b>
 					{% if loop.first %}
-						<br>{{ LNG.ti_category }}: {{ categoryList[$answerRow.categoryID] }}
+						<br>{{ LNG.ti_category }}: {{ categoryList[answerRow.categoryID] }}
 					{% endif %}
 					<hr>
 					<p>

--- a/styles/templates/game/page.trader.default.twig
+++ b/styles/templates/game/page.trader.default.twig
@@ -26,7 +26,7 @@
 				<div class="inner">
 					{% for resourceID, chageData in charge %}
 					<div class="trader_col">
-						{% if !requiredDarkMatter %}<form action="game.php?page=trader" method="post">
+						{% if not requiredDarkMatter %}<form action="game.php?page=trader" method="post">
 						<input type="hidden" name="mode" value="trade">
 						<input type="hidden" name="resource" value="{{ resourceID }}">
 						<input type="image" id="trader_metal" src="{{ dpath }}images/{{ resource[resourceID] }}.gif" title="{{ LNG.tech[resourceID] }}" border="0" height="32" width="52"><br>

--- a/styles/templates/game/shared.information.production.twig
+++ b/styles/templates/game/shared.information.production.twig
@@ -22,7 +22,7 @@
 				<tr>
 					<td><span{% if CurrentLevel == elementLevel %} style="color:#ff0000"{% endif %}>{{ elementLevel }}</span></td>
 					{% for resourceID, production in productionData %}
-					{% set productionDiff = production - $productionTable.production[CurrentLevel][resourceID] %}
+					{% set productionDiff = production - productionTable.production[CurrentLevel][resourceID] %}
 					<td><span style="color:{% if production > 0 %}lime{% elseif production < 0 %}red{% else %}white{% endif %}">{{ production|number_format }}</span></td>
 					<td><span style="color:{% if productionDiff > 0 %}lime{% elseif productionDiff < 0 %}red{% else %}white{% endif %}">{{ productionDiff|number_format }}</span></td>
 					{% endfor %}

--- a/styles/templates/game/shared.information.storage.twig
+++ b/styles/templates/game/shared.information.storage.twig
@@ -24,7 +24,7 @@
 				<tr>
 					<td><span{% if CurrentLevel == elementLevel %} style="color:#ff0000"{% endif %}>{{ elementLevel }}</span></td>
 					{% for resourceID, storage in productionData %}
-					{% set storageDiff = storage - $productionTable.storage[CurrentLevel][resourceID] %}
+					{% set storageDiff = storage - productionTable.storage[CurrentLevel][resourceID] %}
 					<td><span style="color:{% if storage > 0 %}lime{% elseif storage < 0 %}red{% else %}white{% endif %}">{{ storage|number_format }}</span></td>
 					<td><span style="color:{% if storageDiff > 0 %}lime{% elseif storageDiff < 0 %}red{% else %}white{% endif %}">{{ storageDiff|number_format }}</span></td>
 					{% endfor %}

--- a/styles/templates/game/shared.mission.raport.twig
+++ b/styles/templates/game/shared.mission.raport.twig
@@ -16,12 +16,12 @@
 <table>
 	<tr>
 		{% for Player in RoundInfo.attacker %}
-		{% set PlayerInfo = Raport.players[$Player.userID] %}
+		{% set PlayerInfo = Raport.players[Player.userID] %}
 		<td class="transparent">
 			<table>
 				<tr>
 					<td>
-						{{ LNG.sys_attack_attacker_pos }} {{ PlayerInfo.name }} {% if Info is defined %}([XX:XX:XX]){% else %}([{{ PlayerInfo.koords[0] }}:{{ PlayerInfo.koords[1] }}:{{ PlayerInfo.koords[2] }}]{% if PlayerInfo is defined.koords[3] %} ({{ LNG["type_planet_short_{{ PlayerInfo.koords[3] }}"] }}){% endif %}){% endif %}<br>
+						{{ LNG.sys_attack_attacker_pos }} {{ PlayerInfo.name }} {% if Info is defined %}([XX:XX:XX]){% else %}([{{ PlayerInfo.koords[0] }}:{{ PlayerInfo.koords[1] }}:{{ PlayerInfo.koords[2] }}]{% if PlayerInfo.koords[3] is defined %} ({{ LNG.type_planet_short[PlayerInfo.koords[3]] }}){% endif %}){% endif %}<br>
 						{{ LNG.sys_ship_weapon }} {{ PlayerInfo.tech[0] }}% - {{ LNG.sys_ship_shield }} {{ PlayerInfo.tech[1] }}% - {{ LNG.sys_ship_armour }} {{ PlayerInfo.tech[2] }}%
 						<table width="100%">
 						{% if Player.ships %}
@@ -74,12 +74,12 @@
 <table>
 	<tr>
 		{% for Player in RoundInfo.defender %}
-		{% set PlayerInfo = Raport.players[$Player.userID] %}
+		{% set PlayerInfo = Raport.players[Player.userID] %}
 		<td class="transparent">
 			<table>
 				<tr>
 					<td>
-						{{ LNG.sys_attack_defender_pos }} {{ PlayerInfo.name }} {% if Info is defined %}([XX:XX:XX]){% else %}([{{ PlayerInfo.koords[0] }}:{{ PlayerInfo.koords[1] }}:{{ PlayerInfo.koords[2] }}]{% if PlayerInfo is defined.koords[3] %} ({{ LNG.type_planet_short[$PlayerInfo.koords[3]] }}){% endif %}){% endif %}<br>
+						{{ LNG.sys_attack_defender_pos }} {{ PlayerInfo.name }} {% if Info is defined %}([XX:XX:XX]){% else %}([{{ PlayerInfo.koords[0] }}:{{ PlayerInfo.koords[1] }}:{{ PlayerInfo.koords[2] }}]{% if PlayerInfo.koords[3] is defined %} ({{ LNG.type_planet_short[PlayerInfo.koords[3]] }}){% endif %}){% endif %}<br>
 						{{ LNG.sys_ship_weapon }} {{ PlayerInfo.tech[0] }}% - {{ LNG.sys_ship_shield }} {{ PlayerInfo.tech[1] }}% - {{ LNG.sys_ship_armour }} {{ PlayerInfo.tech[2] }}%
 						<table width="100%">
 						{% if Player.ships %}


### PR DESCRIPTION
Fix Twig template syntax errors by removing Smarty remnants and ensuring proper Twig syntax.

This PR addresses various syntax issues, including:
- Converting `&&` to `and` and `||` to `or` operators.
- Removing Smarty `$` prefixes from variables and array access.
- Correcting `is defined.X` syntax to `X is defined` or `array[index] is defined`.
- Balancing `{% if %}` and `{% endif %}` blocks across all templates.

---
<a href="https://cursor.com/background-agent?bcId=bc-90cb601d-cb03-43c2-a6eb-ddd411f5a712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90cb601d-cb03-43c2-a6eb-ddd411f5a712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

