### PR TITLE
Fix twig operator usage

### DIFF
--- a/styles/templates/adm/ModerrationRightsPostPage.twig
+++ b/styles/templates/adm/ModerrationRightsPostPage.twig
@@ -19,7 +19,7 @@
 		{{ File }}
 	</td>
 	<td>
-		{{ yesorno.1 }} <input class="yes" name="rights[{{ File }}]" type="radio"{% if Rights.File == 1 %} checked="checked"{% endif %} value="1"> {{ yesorno.0 }} <input class="no" name="rights[{{ File }}]" type="radio"{% if Rights.File = 1 %} checked="checked"{% endif %} value="0">
+		{{ yesorno.1 }} <input class="yes" name="rights[{{ File }}]" type="radio"{% if Rights.File == 1 %} checked="checked"{% endif %} value="1"> {{ yesorno.0 }} <input class="no" name="rights[{{ File }}]" type="radio"{% if Rights.File == 0 %} checked="checked"{% endif %} value="0">
 	</td>
 </tr>
 {% endfor %}

--- a/styles/templates/game/main.topnav.twig
+++ b/styles/templates/game/main.topnav.twig
@@ -10,7 +10,7 @@
 	        <div class="bar-text">
 		        {% if shortlyNumber %}
 					{% if resourceData.current is not defined %}
-					{{ resourceData.current = resourceData.max + resourceData.used }}
+					{% set resourceData.current = resourceData.max + resourceData.used %}
 						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ shortly_number(resourceData.current) }}&nbsp;/&nbsp;{{ shortly_number(resourceData.max) }}</span></span>
 					{% else %}
 						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
@@ -20,7 +20,7 @@
 					{% endif %}
 		        {% else %}
 					{% if resourceData.current is not defined %}
-					{{ resourceData.current = resourceData.max + resourceData.used }}
+					{% set resourceData.current = resourceData.max + resourceData.used %}
 						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}</span></span>
 					{% else %}
 						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}

--- a/styles/templates/game/shared.information.gate.twig
+++ b/styles/templates/game/shared.information.gate.twig
@@ -3,7 +3,7 @@
 		<tr style="height:20px;">
 			<th colspan="3" class="left">{{ LNG.in_jump_gate_select_ships }}</th>
 		</tr>
-		{% if gateData.restTime = 0 %}
+		{% if gateData.restTime != 0 %}
 		<tr style="height:20px;">
 			<td colspan="3">{{ LNG.in_jump_gate_wait_time }} {{ gateData.nextTime }}&nbsp;(<span class="countdown" data-time="{{ gateData.restTime }}">{pretty_fly_time(gateData.restTime)}</span>)</td>
 		</tr>

--- a/styles/templates/game/shared.information.shipInfo.twig
+++ b/styles/templates/game/shared.information.shipInfo.twig
@@ -24,17 +24,17 @@
 			<td style="width:50%">{{ FleetInfo.capacity|number}</td>
 		</tr>
 		{% endif %}
-		{% if FleetInfo.speed1 %}
-		<tr>
-			<td style="width:50%">{{ LNG.in_base_speed }}</td>
-			<td style="width:50%">{{ FleetInfo.speed1|number}{% if FleetInfo.speed1 = FleetInfo.speed2 %} <span style="color:yellow">({{ FleetInfo.speed2|number})</span>{% endif %}</td>
-		</tr>
-		{% endif %}
-		{% if FleetInfo.consumption1 %}
-		<tr>
-			<td style="width:50%">{{ LNG.in_consumption }}</td>
-			<td style="width:50%">{{ FleetInfo.consumption1|number}{% if FleetInfo.consumption1 = FleetInfo.consumption2 %} <span style="color:yellow">({{ FleetInfo.consumption2|number})</span>{% endif %}</td>
-		</tr>
-		{% endif %}
+	{% if FleetInfo.speed1 %}
+	<tr>
+		<td style="width:50%">{{ LNG.in_base_speed }}</td>
+		<td style="width:50%">{{ FleetInfo.speed1|number}{% if FleetInfo.speed1 != FleetInfo.speed2 %} <span style="color:yellow">({{ FleetInfo.speed2|number})</span>{% endif %}</td>
+	</tr>
+	{% endif %}
+	{% if FleetInfo.consumption1 %}
+	<tr>
+		<td style="width:50%">{{ LNG.in_consumption }}</td>
+		<td style="width:50%">{{ FleetInfo.consumption1|number}{% if FleetInfo.consumption1 != FleetInfo.consumption2 %} <span style="color:yellow">({{ FleetInfo.consumption2|number})</span>{% endif %}</td>
+	</tr>
+	{% endif %}
 	</tbody>
 </table>

--- a/styles/templates/game/shared.statistics.playerTable.twig
+++ b/styles/templates/game/shared.statistics.playerTable.twig
@@ -9,8 +9,8 @@
 <tr>
 	<td><a class="tooltip" data-tooltip-content="{% if RangeInfo.ranking == 0 %}<span style='color:#87CEEB'>*</span>{% elseif RangeInfo.ranking < 0 %}<span style='color:red'>-{{ RangeInfo.ranking }}</span>{% elseif RangeInfo.ranking > 0 %}<span style='color:green'>+{{ RangeInfo.ranking }}</span>{% endif %}">{{ RangeInfo.rank }}</a></td>
 	<td><a href="#" onclick="return Dialog.Playercard({{ RangeInfo.id }}, '{{ RangeInfo.name }}');"{% if RangeInfo.id == CUser_id %} style="color:lime"{% endif %}>{{ RangeInfo.name }}</a></td>
-	<td>{% if RangeInfo.id = CUser_id %}<a href="#" onclick="return Dialog.PM({{ RangeInfo.id }});"><i class="far fa-envelope" title="{{ LNG.st_write_message }}" style="font-size: 15px;"></i></a>{% endif %}</td>
-	<td>{% if RangeInfo.allyid = 0 %}<a href="game.php?page=alliance&amp;mode=info&amp;id={{ RangeInfo.allyid }}">{% if RangeInfo.allyid == CUser_ally %}<span style="color:#33CCFF">{{ RangeInfo.allyname }}</span>{% else %}{{ RangeInfo.allyname }}{% endif %}</a>{% else %}-{% endif %}</td>
+	<td>{% if RangeInfo.id != CUser_id %}<a href="#" onclick="return Dialog.PM({{ RangeInfo.id }});"><i class="far fa-envelope" title="{{ LNG.st_write_message }}" style="font-size: 15px;"></i></a>{% endif %}</td>
+	<td>{% if RangeInfo.allyid != 0 %}<a href="game.php?page=alliance&amp;mode=info&amp;id={{ RangeInfo.allyid }}">{% if RangeInfo.allyid == CUser_ally %}<span style="color:#33CCFF">{{ RangeInfo.allyname }}</span>{% else %}{{ RangeInfo.allyname }}{% endif %}</a>{% else %}-{% endif %}</td>
 	<td>{{ RangeInfo.points }}</td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
Correct Twig template operators from Smarty-style assignments/comparisons to proper Twig syntax.

Templates previously used the `=` operator for both variable assignments and comparisons, a syntax carried over from Smarty. This PR updates these instances to use `{% set %}` for assignments and `==` or `!=` for comparisons, ensuring compatibility with Twig's stricter parsing rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-627a21aa-3582-49db-bb16-bdc90a1f899d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-627a21aa-3582-49db-bb16-bdc90a1f899d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

