### PR TITLE
Fix smarty syntax in twig templates

### DIFF
--- a/styles/templates/game/page.alliance.admin.overview.twig
+++ b/styles/templates/game/page.alliance.admin.overview.twig
@@ -80,12 +80,10 @@
 				<td>
 					<select name="events[]" size="{{ available_events|length }}" multiple>
 						{% for id, mission in available_events %}
+							{% set selected = '' %}
 							{% for selected_events in ally_events %}
 								{% if selected_events == id %}
-									{assign var=selected value=selected}
-									{break}
-								{% else %}
-									{assign var=selected value=''}
+									{% set selected = 'selected' %}
 								{% endif %}
 							{% endfor %}
 							<option value="{{ id }}" {{ selected }}>{{ mission }}</option>

--- a/styles/templates/game/shared.mission.raport.twig
+++ b/styles/templates/game/shared.mission.raport.twig
@@ -153,7 +153,7 @@
 		{{ LNG.sys_destruc_stop }}<br>
 	{% else %}
 		{#  Attack win  #}
-		{{ sprintf(LNG.sys_destruc_lune, "{{ Raport.moon.moonDestroyChance }}")}<br>{{ LNG.sys_destruc_mess1 }}
+		{{ sprintf(LNG.sys_destruc_lune, Raport.moon.moonDestroyChance) }}<br>{{ LNG.sys_destruc_mess1 }}
 		{% if Raport.moon.moonDestroySuccess == 1 %}
 			{#  Destroy success  #}
 			{{ LNG.sys_destruc_reussi }}


### PR DESCRIPTION
Correct invalid Smarty syntax and Twig interpolation issues in templates to ensure proper rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4031e23-4cee-4d82-b3ee-d75010c9a4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4031e23-4cee-4d82-b3ee-d75010c9a4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

