### PR TITLE
Correct invalid twig assignment syntax in templates

### DIFF
--- a/styles/templates/game/main.topnav.twig
+++ b/styles/templates/game/main.topnav.twig
@@ -8,27 +8,27 @@
 	      <div class="bar-container">
 	        <div class="bar bar_{{ resourceID }}" style="width: 0%;"></div>
 	        <div class="bar-text">
-		        {% if shortlyNumber %}
-					{% if resourceData.current is not defined %}
-					{% set resourceData.current = resourceData.max + resourceData.used %}
-						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ shortly_number(resourceData.current) }}&nbsp;/&nbsp;{{ shortly_number(resourceData.max) }}</span></span>
+	        {% if shortlyNumber %}
+				{% if resourceData.current is not defined %}
+				{% set resCurrent = resourceData.max + resourceData.used %}
+					<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resCurrent|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resCurrent < 0 %} style="color:red"{% endif %}>{{ shortly_number(resCurrent) }}&nbsp;/&nbsp;{{ shortly_number(resourceData.max) }}</span></span>
+				{% else %}
+					<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
 					{% else %}
-						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
-						{% else %}
-						<span class='res_max' id='max_{{ resourceData.name }}' data-real='{{ resourceData.max }}'>{{ shortly_number(resourceData.max) }}</span>
-						{% endif %}">{{ shortly_number(resourceData.current) }}</span>
-					{% endif %}
-		        {% else %}
-					{% if resourceData.current is not defined %}
-					{% set resourceData.current = resourceData.max + resourceData.used %}
-						<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resourceData.current < 0 %} style="color:red"{% endif %}>{{ resourceData.current|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}</span></span>
+					<span class='res_max' id='max_{{ resourceData.name }}' data-real='{{ resourceData.max }}'>{{ shortly_number(resourceData.max) }}</span>
+					{% endif %}">{{ shortly_number(resourceData.current) }}</span>
+				{% endif %}
+	        {% else %}
+				{% if resourceData.current is not defined %}
+				{% set resCurrent = resourceData.max + resourceData.used %}
+					<span class="res_current tooltip" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resCurrent|number_format }}&nbsp;/&nbsp;{{ resourceData.max|number_format }}"><span{% if resCurrent < 0 %} style="color:red"{% endif %}>{{ resCurrent|number_format }}&nbsp;/&nbsp;{{ resCurrent|number_format }}</span></span>
+				{% else %}
+					<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
 					{% else %}
-						<span class="res_current tooltip" id="current_{{ resourceData.name }}" data-tooltip-content="{{ LNG.tech[resourceID] }} <br> {{ resourceData.current|number_format }} <br> {% if resourceData.current is not defined or resourceData.max is not defined %}
-						{% else %}
-						<span class='res_max' id='max_{{ resourceData.name }}' data-real='{{ resourceData.max }}'>{{ shortly_number(resourceData.max) }}</span>
-						{% endif %}" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}">{{ resourceData.current|number_format }} (X%)</span>
-					{% endif %}
-		        {% endif %}
+					<span class='res_max' id='max_{{ resourceData.name }}' data-real='{{ resourceData.max }}'>{{ shortly_number(resourceData.max) }}</span>
+					{% endif %}" id="current_{{ resourceData.name }}" data-real="{{ resourceData.current }}">{{ resourceData.current|number_format }} (X%)</span>
+				{% endif %}
+	        {% endif %}
 	        </div>
 	      </div>
 	      {% if resourceID != 911 and resourceID != 921 %}


### PR DESCRIPTION
Fix invalid Twig assignment to object properties in `main.topnav.twig`.

Twig does not allow direct assignment to object properties using dot notation within `{% set %}` blocks. This change introduces a temporary variable to store the calculated value, resolving the syntax issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-50f6fe9a-59dc-4587-80ae-e6118ebd3c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50f6fe9a-59dc-4587-80ae-e6118ebd3c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

