### PR TITLE
Stabilize SmartMoon Twig and PHP components

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -130,12 +130,13 @@ function locale_date_format(string $format, int $time, $LNG = null): string
 	return $format;
 }
 
-function _date(string $format, ?int $time = null, ?string $toTimeZone = null, $LNG = null): string
+function _date(string $format, mixed $time = null, ?string $toTimeZone = null, $LNG = null): string
 {
-	if ($time === false || $time === null) {
+	// Handle false, null, empty string, and cast safely to int
+	if ($time === false || $time === null || $time === '') {
 		$time = TIMESTAMP;
 	} else {
-		$time = (int)floor($time);
+		$time = (int)floor((float)$time);
 	}
 
 	if(isset($toTimeZone))

--- a/includes/classes/BBCode.class.php
+++ b/includes/classes/BBCode.class.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 class BBCode
 {
-	static public function parse(string $sText): string
+	static public function parse(?string $sText): string
 	{
 		$sText = !empty($sText)?$sText:'';
 		// Convert Windows (\r\n) to Unix (\n)

--- a/includes/classes/class.template.php
+++ b/includes/classes/class.template.php
@@ -125,6 +125,16 @@ class template
 		$this->twig->addFilter(new TwigFilter('time', function($seconds) {
 			return pretty_time($seconds);
 		}));
+		
+		// Register number filter alias for number_format
+		$this->twig->addFilter(new TwigFilter('number', function($number, int $decimals = 0, string $decPoint = ',', string $thousandsSep = '.') {
+			return number_format((float)$number, $decimals, $decPoint, $thousandsSep);
+		}));
+		
+		// Register json filter alias for json_encode
+		$this->twig->addFilter(new TwigFilter('json', function($value, int $options = 0, int $depth = 512) {
+			return json_encode($value, $options, $depth);
+		}));
 	}
 
 	private function getTempPath(): string

--- a/includes/pages/game/ShowAlliancePage.class.php
+++ b/includes/pages/game/ShowAlliancePage.class.php
@@ -154,7 +154,7 @@ class ShowAlliancePage extends AbstractGamePage
 		$this->assign(array(
 			'diplomaticData'				=> $diplomaticmaticData,
 			'statisticData'					=> $statisticData,
-			'ally_description' 				=> BBCode::parse($this->allianceData['ally_description']),
+			'ally_description' 				=> BBCode::parse($this->allianceData['ally_description'] ?? ''),
 			'ally_id'	 					=> $this->allianceData['id'],
 			'ally_image' 					=> $this->allianceData['ally_image'],
 			'ally_web'						=> $this->allianceData['ally_web'],

--- a/styles/templates/game/page.buildings.default.twig
+++ b/styles/templates/game/page.buildings.default.twig
@@ -15,8 +15,8 @@
 			{% set ID = List.element %}
 			<tr>
 				<td style="width:70%;vertical-align:top;" class="left">
-					{{ loop.index }}.: 
-					{% if !(isBusy.research and (ID == 6 or ID == 31)) and !(isBusy.shipyard and (ID == 15 or ID == 21)) and RoomIsOk and CanBuildElement and BuildInfoList[ID].buyable %}
+				{{ loop.index }}.: 
+				{% if not (isBusy.research and (ID == 6 or ID == 31)) and not (isBusy.shipyard and (ID == 15 or ID == 21)) and RoomIsOk and CanBuildElement and BuildInfoList[ID].buyable %}
 					<form class="build_form" action="game.php?page=buildings" method="post">
 						<input type="hidden" name="cmd" value="insert">
 						<input type="hidden" name="building" value="{{ ID }}">


### PR DESCRIPTION
Improve SmartMoon's Twig and PHP stability by enhancing type safety, adding Twig filter aliases, and correcting template syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c7b0509-0190-456e-9acd-acaf46bd244e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c7b0509-0190-456e-9acd-acaf46bd244e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

