### PR TITLE
Fix admin database connection credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ SmartMoons-v3.0/
 
 ## 📖 Changelog
 
+### **v3.3.4** _(2025-10-02)_
+**🐛 Bugfix: Admin Panel Database Connection**
+- ✅ Fixed Database_BC connection issue - Admin panel now loads correctly
+- ✅ Updated `Database_BC.class.php` to properly include `includes/config.php`
+- ✅ Added proper path resolution using ROOT_PATH or __DIR__
+- ✅ Changed charset from utf8 to utf8mb4 for better Unicode support
+- ✅ Fixed "Access denied for user ''@'localhost'" error
+- 📝 Changed by: **0wum0**
+
 ### **v3.3.3** _(2025-10-01)_
 **🐛 Bugfixes**
 - ✅ Fixed invalid Twig bracket syntax in multiple templates

--- a/includes/classes/Database_BC.class.php
+++ b/includes/classes/Database_BC.class.php
@@ -36,11 +36,19 @@ class Database_BC extends mysqli
 	public function __construct()
 	{
 		$databaseConfig = array();
-		require_once 'includes/config.php';
+		
+		// Load database configuration from config.php
+		// Use ROOT_PATH if defined, otherwise construct path relative to this file
+		if (defined('ROOT_PATH')) {
+			require_once ROOT_PATH . 'includes/config.php';
+		} else {
+			require_once __DIR__ . '/../../includes/config.php';
+		}
 
-        if (!isset($databaseConfig['port'])) {
-            $databaseConfig['port'] = 3306;
-        }
+		// Set default port if not specified
+		if (!isset($databaseConfig['port'])) {
+			$databaseConfig['port'] = 3306;
+		}
 
 		@parent::__construct($databaseConfig['host'], $databaseConfig['user'], $databaseConfig['password'], $databaseConfig['dbname'], $databaseConfig['port']);
 
@@ -48,7 +56,9 @@ class Database_BC extends mysqli
 		{
 			throw new Exception("Connection to database failed: ".mysqli_connect_error());
 		}
-		parent::set_charset("utf8");
+		
+		// Set charset to utf8mb4 for better Unicode support
+		parent::set_charset("utf8mb4");
 		#parent::query("SET SESSION sql_mode = '';");
 		parent::query("SET SESSION sql_mode = 'STRICT_ALL_TABLES';");
 	}


### PR DESCRIPTION
Fix `Database_BC` connection by correcting the `config.php` include path and setting `utf8mb4` charset.

The `Database_BC.class.php` constructor failed to load database credentials from `includes/config.php` because the `require_once` path was relative to the class file (`includes/classes/`) instead of the application root. This resulted in "Access denied" errors for the Admin panel. The fix uses `ROOT_PATH` (if defined) or a `__DIR__` fallback to ensure the config file is loaded correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6ff6be9-7786-47e9-beee-5dda90038b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6ff6be9-7786-47e9-beee-5dda90038b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

