### PR TITLE
Validate database connection credentials

### DIFF
--- a/includes/classes/Database_BC.class.php
+++ b/includes/classes/Database_BC.class.php
@@ -45,12 +45,26 @@ class Database_BC extends mysqli
 			require_once __DIR__ . '/../../includes/config.php';
 		}
 
+		// Validate required database credentials
+		if (empty($databaseConfig['host'])) {
+			throw new Exception("Database configuration error: 'host' is missing or empty. Please check includes/config.php");
+		}
+		if (empty($databaseConfig['user'])) {
+			throw new Exception("Database configuration error: 'user' is missing or empty. Please check includes/config.php");
+		}
+		if (empty($databaseConfig['dbname'])) {
+			throw new Exception("Database configuration error: 'dbname' is missing or empty. Please check includes/config.php");
+		}
+
+		// Set optional password with default empty string
+		$password = $databaseConfig['password'] ?? '';
+
 		// Set default port if not specified
 		if (!isset($databaseConfig['port'])) {
 			$databaseConfig['port'] = 3306;
 		}
 
-		@parent::__construct($databaseConfig['host'], $databaseConfig['user'], $databaseConfig['password'], $databaseConfig['dbname'], $databaseConfig['port']);
+		@parent::__construct($databaseConfig['host'], $databaseConfig['user'], $password, $databaseConfig['dbname'], $databaseConfig['port']);
 
 		if(mysqli_connect_error())
 		{


### PR DESCRIPTION
Add config validation to the `Database_BC` constructor to prevent connection attempts with empty credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-61fe96e5-0602-4127-ac0d-d351e27188de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61fe96e5-0602-4127-ac0d-d351e27188de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

