### PR TITLE
Fix database config loading in Database_BC

### DIFF
--- a/includes/classes/Database.class.php
+++ b/includes/classes/Database.class.php
@@ -47,17 +47,29 @@ class Database
         // Config laden
         require 'includes/config.php';
 
-        // Standardwerte setzen, falls Keys fehlen
-        $defaults = [
-            'host'     => 'localhost',
-            'port'     => 3306,
-            'user'     => 'root',
-            'password' => '',
-            'dbname'   => '',
-            'prefix'   => '',
-        ];
+        // Validate required database credentials
+        if (empty($databaseConfig['host'])) {
+            throw new Exception("Database configuration error: 'host' is missing or empty. Please check includes/config.php");
+        }
+        if (empty($databaseConfig['user'])) {
+            throw new Exception("Database configuration error: 'user' is missing or empty. Please check includes/config.php");
+        }
+        if (!isset($databaseConfig['password'])) {
+            throw new Exception("Database configuration error: 'password' is missing. Please check includes/config.php");
+        }
+        if (empty($databaseConfig['dbname'])) {
+            throw new Exception("Database configuration error: 'dbname' is missing or empty. Please check includes/config.php");
+        }
 
-        $databaseConfig = array_merge($defaults, $databaseConfig ?? []);
+        // Set default port if not specified
+        if (!isset($databaseConfig['port'])) {
+            $databaseConfig['port'] = 3306;
+        }
+
+        // Set default prefix if not specified
+        if (!isset($databaseConfig['prefix'])) {
+            $databaseConfig['prefix'] = '';
+        }
 
         // DSN erstellen
         $dsn = sprintf(

--- a/includes/classes/Database_BC.class.php
+++ b/includes/classes/Database_BC.class.php
@@ -52,12 +52,15 @@ class Database_BC extends mysqli
 		if (empty($databaseConfig['user'])) {
 			throw new Exception("Database configuration error: 'user' is missing or empty. Please check includes/config.php");
 		}
+		if (!isset($databaseConfig['password'])) {
+			throw new Exception("Database configuration error: 'password' is missing. Please check includes/config.php");
+		}
 		if (empty($databaseConfig['dbname'])) {
 			throw new Exception("Database configuration error: 'dbname' is missing or empty. Please check includes/config.php");
 		}
 
-		// Set optional password with default empty string
-		$password = $databaseConfig['password'] ?? '';
+		// Password can be empty string but must exist in config
+		$password = $databaseConfig['password'];
 
 		// Set default port if not specified
 		if (!isset($databaseConfig['port'])) {

--- a/includes/config.sample.php
+++ b/includes/config.sample.php
@@ -18,15 +18,17 @@ declare(strict_types=1);
  */
 
 //### Database access ###//
+// IMPORTANT: This must be a plain PHP array, NOT a return statement
+// The Database classes require all keys to be present
 
 $databaseConfig				= array();
-$databaseConfig['host']		= '%s';
-$databaseConfig['port']		= %s;
-$databaseConfig['user']		= '%s';
-$databaseConfig['password']	= '%s';
-$databaseConfig['dbname']	= '%s';
-$databaseConfig['prefix']	= '%s';
-$salt						= '%s'; // 22 digits from the alphabet "./0-9A-Za-z"
+$databaseConfig['host']		= '%s';        // Database host (e.g., 'localhost' or IP address)
+$databaseConfig['port']		= %s;          // Database port (default: 3306)
+$databaseConfig['user']		= '%s';        // Database username
+$databaseConfig['password']	= '%s';        // Database password (can be empty string '')
+$databaseConfig['dbname']	= '%s';        // Database name
+$databaseConfig['prefix']	= '%s';        // Table prefix (e.g., 'uni1_')
+$salt						= '%s';        // 22 digits from the alphabet "./0-9A-Za-z"
 
 //### Do not change beyond here ###//
 ?>


### PR DESCRIPTION
Enhance database configuration validation in both `Database.class.php` and `Database_BC.class.php` to prevent connection errors and provide clearer feedback.

The previous configuration loading was inconsistent between the MySQLi and PDO database classes, and `password` was not always validated. This PR standardizes robust validation across both classes, ensuring all critical database parameters (`host`, `user`, `password`, `dbname`) are present and providing explicit error messages if they are not. `config.sample.php` is also updated for clarity and to emphasize the expected plain PHP array format.

---
<a href="https://cursor.com/background-agent?bcId=bc-115e8761-3fbb-4829-926b-e4c984ca4279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-115e8761-3fbb-4829-926b-e4c984ca4279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

