### PR TITLE
Fix database and common file issues

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -202,15 +202,9 @@ if (MODE === 'INGAME' || MODE === 'ADMIN' || MODE === 'CRON')
 	{
 		error_reporting(E_ERROR | E_WARNING | E_PARSE);
 		
-		// Robust handling for USER['rights'] to prevent unserialize(null) errors
-		if (!empty($USER['rights']) && is_string($USER['rights'])) {
-			$decoded = @unserialize($USER['rights']);
-			if ($decoded === false && $USER['rights'] !== 'b:0;') {
-				$USER['rights'] = [];
-			} else {
-				$USER['rights'] = $decoded;
-			}
-		} else {
+		// Safe handling for USER['rights'] to prevent unserialize warnings
+		$USER['rights'] = empty($USER['rights']) ? [] : @unserialize($USER['rights']);
+		if (!is_array($USER['rights'])) {
 			$USER['rights'] = [];
 		}
 		


### PR DESCRIPTION
Simplify and secure `unserialize` handling for `$USER['rights']` in `common.php`.

This change prevents `unserialize` warnings and ensures `$USER['rights']` is always an array, improving robustness and PHP 8.3 compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-eafbca22-1db2-4a13-8da2-b78341e7b7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eafbca22-1db2-4a13-8da2-b78341e7b7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

