### PR TITLE
Fix unclosed parenthesis in OverviewBody.twig

### DIFF
--- a/styles/templates/adm/OverviewBody.twig
+++ b/styles/templates/adm/OverviewBody.twig
@@ -1,7 +1,7 @@
 {% include "overall_header.twig" %}
 <center>
 	<h1>{{ LNG.ow_title }}</h1>
-	<table width="90%" style="border:2px {% if empty(Messages %}lime{% else %}red{% endif %} solid;text-align:center;font-weight:bold;">
+	<table width="90%" style="border:2px {% if Messages is empty %}lime{% else %}red{% endif %} solid;text-align:center;font-weight:bold;">
 		<tr>
 			<td class="transparent">{% for Message in Messages %}
 					<span style="color:red">{{ Message }}</span><br>


### PR DESCRIPTION
Fix invalid Twig syntax in `OverviewBody.twig` to resolve an 'unclosed bracket' parse error.

The `empty()` function call with an unclosed parenthesis `{% if empty(Messages %}` was replaced with the Twig-idiomatic `{% if Messages is empty %}` to ensure proper template parsing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9f7fcc6-3c26-4c6e-aa21-50e984dd636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9f7fcc6-3c26-4c6e-aa21-50e984dd636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

