### PR TITLE
Define timestamp constant safely

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -39,7 +39,9 @@ date_default_timezone_set(@date_default_timezone_get());
 
 ini_set('display_errors', '1');
 header('Content-Type: text/html; charset=UTF-8');
-define('TIMESTAMP',	time());
+if (!defined('TIMESTAMP')) {
+    define('TIMESTAMP', time());
+}
 	
 require_once 'includes/constants.php';
 
@@ -236,7 +238,9 @@ date_default_timezone_set(@date_default_timezone_get());
 
 ini_set('display_errors', '1');
 header('Content-Type: text/html; charset=UTF-8');
-define('TIMESTAMP',	time());
+if (!defined('TIMESTAMP')) {
+    define('TIMESTAMP', time());
+}
 	
 require_once 'includes/constants.php';
 


### PR DESCRIPTION
Replace `define('TIMESTAMP', time());` with a conditional check to prevent "Constant TIMESTAMP already defined" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fea9980-2506-4819-b62d-3c7ab72f956d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fea9980-2506-4819-b62d-3c7ab72f956d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

