### PR TITLE
Fix unbalanced parenthesis in adm showmenu twig

### DIFF
--- a/styles/templates/adm/ShowMenuPage.twig
+++ b/styles/templates/adm/ShowMenuPage.twig
@@ -3,44 +3,44 @@
 	<ul id="menu">
 		<li style="background-image: url('./styles/theme/gow/img/menu-top.png');height:100px;"></li>
 		<li><a href="javascript:void(0);"><span style="color:lime">{{ LNG.mu_general }}</span></a></li>
-		{% if allowedTo('ShowInformationPage' %}<li><a href="?page=infos" target="Hauptframe">{{ LNG.mu_game_info }}</a></li>{% endif %}
-		{% if allowedTo('ShowConfigBasicPage' %}<li><a href="?page=config" target="Hauptframe">{{ LNG.mu_settings }}</a></li>{% endif %}
-		{% if allowedTo('ShowConfigUniPage' %}<li><a href="?page=configuni" target="Hauptframe">{{ LNG.mu_unisettings }}</a></li>{% endif %}
-		{% if allowedTo('ShowConfigModsPage' %}<li><a href="?page=configmods" target="Hauptframe">{{ LNG.mu_mods_settings }}</a></li>{% endif %}
-		{% if allowedTo('ShowChatConfigPage' %}<li><a href="?page=chat" target="Hauptframe">{{ LNG.mu_chat }}</a></li>{% endif %}
-		{% if allowedTo('ShowTeamspeakPage' %}<li><a href="?page=teamspeak" target="Hauptframe">{{ LNG.mu_ts_options }}</a></li>{% endif %}
-		{% if allowedTo('ShowFacebookPage' %}<li><a href="?page=facebook" target="Hauptframe">{{ LNG.mu_fb_options }}</a></li>{% endif %}
-		{% if allowedTo('ShowModulePage' %}<li><a href="?page=module" target="Hauptframe">{{ LNG.mu_module }}</a></li>{% endif %}
-		{% if allowedTo('ShowDisclamerPage' %}<li><a href="?page=disclamer" target="Hauptframe">{{ LNG.mu_disclaimer }}</a></li>{% endif %}
-		{% if allowedTo('ShowStatsPage' %}<li><a href="?page=statsconf" target="Hauptframe">{{ LNG.mu_stats_options }}</a></li>{% endif %}
+		{% if allowedTo('ShowInformationPage') %}<li><a href="?page=infos" target="Hauptframe">{{ LNG.mu_game_info }}</a></li>{% endif %}
+		{% if allowedTo('ShowConfigBasicPage') %}<li><a href="?page=config" target="Hauptframe">{{ LNG.mu_settings }}</a></li>{% endif %}
+		{% if allowedTo('ShowConfigUniPage') %}<li><a href="?page=configuni" target="Hauptframe">{{ LNG.mu_unisettings }}</a></li>{% endif %}
+		{% if allowedTo('ShowConfigModsPage') %}<li><a href="?page=configmods" target="Hauptframe">{{ LNG.mu_mods_settings }}</a></li>{% endif %}
+		{% if allowedTo('ShowChatConfigPage') %}<li><a href="?page=chat" target="Hauptframe">{{ LNG.mu_chat }}</a></li>{% endif %}
+		{% if allowedTo('ShowTeamspeakPage') %}<li><a href="?page=teamspeak" target="Hauptframe">{{ LNG.mu_ts_options }}</a></li>{% endif %}
+		{% if allowedTo('ShowFacebookPage') %}<li><a href="?page=facebook" target="Hauptframe">{{ LNG.mu_fb_options }}</a></li>{% endif %}
+		{% if allowedTo('ShowModulePage') %}<li><a href="?page=module" target="Hauptframe">{{ LNG.mu_module }}</a></li>{% endif %}
+		{% if allowedTo('ShowDisclamerPage') %}<li><a href="?page=disclamer" target="Hauptframe">{{ LNG.mu_disclaimer }}</a></li>{% endif %}
+		{% if allowedTo('ShowStatsPage') %}<li><a href="?page=statsconf" target="Hauptframe">{{ LNG.mu_stats_options }}</a></li>{% endif %}
 		{#  if allowedTo('ShowVertifyPage')}<li><a href="?page=vertify" target="Hauptframe">{{ LNG.mu_vertify }}</a></li>{/if  #}
-		{% if allowedTo('ShowCronjobPage' %}<li><a href="?page=cronjob" target="Hauptframe">{{ LNG.mu_cronjob }}</a></li>{% endif %}
-		{% if allowedTo('ShowDumpPage' %}<li><a href="?page=dump" target="Hauptframe">{{ LNG.mu_dump }}</a></li>{% endif %}
+		{% if allowedTo('ShowCronjobPage') %}<li><a href="?page=cronjob" target="Hauptframe">{{ LNG.mu_cronjob }}</a></li>{% endif %}
+		{% if allowedTo('ShowDumpPage') %}<li><a href="?page=dump" target="Hauptframe">{{ LNG.mu_dump }}</a></li>{% endif %}
 		<li><a href="javascript:void(0);"><span style="color:lime">{{ LNG.mu_users_settings }}</span></a></li>
-		{% if allowedTo('ShowCreatorPage' %}<li><a href="?page=create" target="Hauptframe">{{ LNG.new_creator_title }}</a></li>{% endif %}
-		{% if allowedTo('ShowAccountEditorPage' %}<li><a href="?page=accounteditor" target="Hauptframe">{{ LNG.mu_add_delete_resources }}</a></li>{% endif %}
-		{% if allowedTo('ShowBanPage' %}<li><a href="?page=bans" target="Hauptframe">{{ LNG.mu_ban_options }}</a></li>{% endif %}
-		{% if allowedTo('ShowGiveawayPage' %}<li><a href="?page=giveaway" target="Hauptframe">{{ LNG.mu_giveaway }}</a></li>{% endif %}
+		{% if allowedTo('ShowCreatorPage') %}<li><a href="?page=create" target="Hauptframe">{{ LNG.new_creator_title }}</a></li>{% endif %}
+		{% if allowedTo('ShowAccountEditorPage') %}<li><a href="?page=accounteditor" target="Hauptframe">{{ LNG.mu_add_delete_resources }}</a></li>{% endif %}
+		{% if allowedTo('ShowBanPage') %}<li><a href="?page=bans" target="Hauptframe">{{ LNG.mu_ban_options }}</a></li>{% endif %}
+		{% if allowedTo('ShowGiveawayPage') %}<li><a href="?page=giveaway" target="Hauptframe">{{ LNG.mu_giveaway }}</a></li>{% endif %}
 		<li><a href="javascript:void(0);"><span style="color:lime">{{ LNG.mu_observation }}</span></a></li>
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search&amp;search=online&amp;minimize=on" target="Hauptframe">{{ LNG.mu_connected }}</a></li>{% endif %}
-		{% if allowedTo('ShowSupportPage' %}<li><a href="?page=support" target="Hauptframe">{{ LNG.mu_support }}{% if supportticks == 0 %} ({{ supportticks }}){% endif %}</a></li>{% endif %}
-		{% if allowedTo('ShowActivePage' %}<li><a href="?page=active" target="Hauptframe">{{ LNG.mu_vaild_users }}</a></li>{% endif %}
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search&amp;search=p_connect&amp;minimize=on" target="Hauptframe">{{ LNG.mu_active_planets }}</a></li>{% endif %}
-		{% if allowedTo('ShowFlyingFleetPage' %}<li><a href="?page=fleets" target="Hauptframe">{{ LNG.mu_flying_fleets }}</a></li>{% endif %}
-		{% if allowedTo('ShowNewsPage' %}<li><a href="?page=news" target="Hauptframe">{{ LNG.mu_news }}</a></li>{% endif %}
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search&amp;search=users&amp;minimize=on" target="Hauptframe">{{ LNG.mu_user_list }}</a></li>{% endif %}
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search&amp;search=planet&amp;minimize=on" target="Hauptframe">{{ LNG.mu_planet_list }}</a></li>{% endif %}
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search&amp;search=moon&amp;minimize=on" target="Hauptframe">{{ LNG.mu_moon_list }}</a></li>{% endif %}
-		{% if allowedTo('ShowMessageListPage' %}<li><a href="?page=messagelist" target="Hauptframe">{{ LNG.mu_mess_list }}</a></li>{% endif %}
-		{% if allowedTo('ShowAccountDataPage' %}<li><a href="?page=accountdata" target="Hauptframe">{{ LNG.mu_info_account_page }}</a></li>{% endif %}
-		{% if allowedTo('ShowSearchPage' %}<li><a href="?page=search" target="Hauptframe">{{ LNG.mu_search_page }}</a></li>{% endif %}
-		{% if allowedTo('ShowMultiIPPage' %}<li><a href="?page=multiips" target="Hauptframe">{{ LNG.mu_multiip_page }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search&amp;search=online&amp;minimize=on" target="Hauptframe">{{ LNG.mu_connected }}</a></li>{% endif %}
+		{% if allowedTo('ShowSupportPage') %}<li><a href="?page=support" target="Hauptframe">{{ LNG.mu_support }}{% if supportticks == 0 %} ({{ supportticks }}){% endif %}</a></li>{% endif %}
+		{% if allowedTo('ShowActivePage') %}<li><a href="?page=active" target="Hauptframe">{{ LNG.mu_vaild_users }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search&amp;search=p_connect&amp;minimize=on" target="Hauptframe">{{ LNG.mu_active_planets }}</a></li>{% endif %}
+		{% if allowedTo('ShowFlyingFleetPage') %}<li><a href="?page=fleets" target="Hauptframe">{{ LNG.mu_flying_fleets }}</a></li>{% endif %}
+		{% if allowedTo('ShowNewsPage') %}<li><a href="?page=news" target="Hauptframe">{{ LNG.mu_news }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search&amp;search=users&amp;minimize=on" target="Hauptframe">{{ LNG.mu_user_list }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search&amp;search=planet&amp;minimize=on" target="Hauptframe">{{ LNG.mu_planet_list }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search&amp;search=moon&amp;minimize=on" target="Hauptframe">{{ LNG.mu_moon_list }}</a></li>{% endif %}
+		{% if allowedTo('ShowMessageListPage') %}<li><a href="?page=messagelist" target="Hauptframe">{{ LNG.mu_mess_list }}</a></li>{% endif %}
+		{% if allowedTo('ShowAccountDataPage') %}<li><a href="?page=accountdata" target="Hauptframe">{{ LNG.mu_info_account_page }}</a></li>{% endif %}
+		{% if allowedTo('ShowSearchPage') %}<li><a href="?page=search" target="Hauptframe">{{ LNG.mu_search_page }}</a></li>{% endif %}
+		{% if allowedTo('ShowMultiIPPage') %}<li><a href="?page=multiips" target="Hauptframe">{{ LNG.mu_multiip_page }}</a></li>{% endif %}
 		<li><a href="javascript:void(0);"><span style="color:lime">{{ LNG.mu_tools }}</span></a></li>
-		{% if allowedTo('ShowLogPage' %}<li><a href="?page=log" target="Hauptframe">{{ LNG.mu_logs }}</a></li>{% endif %}
-		{% if allowedTo('ShowSendMessagesPage' %}<li><a href="?page=globalmessage" target="Hauptframe">{{ LNG.mu_global_message }}</a></li>{% endif %}
-		{% if allowedTo('ShowPassEncripterPage' %}<li><a href="?page=password" target="Hauptframe">{{ LNG.mu_md5_encripter }}</a></li>{% endif %}
-		{% if allowedTo('ShowStatUpdatePage' %}<li><a href="?page=statsupdate" target="Hauptframe" onClick=" return confirm('{{ LNG.mu_mpu_confirmation }}');">{{ LNG.mu_manual_points_update }}</a></li>{% endif %}
-		{% if allowedTo('ShowClearCachePage' %}<li><a href="?page=clearcache" target="Hauptframe">{{ LNG.mu_clear_cache }}</a></li>{% endif %}
+		{% if allowedTo('ShowLogPage') %}<li><a href="?page=log" target="Hauptframe">{{ LNG.mu_logs }}</a></li>{% endif %}
+		{% if allowedTo('ShowSendMessagesPage') %}<li><a href="?page=globalmessage" target="Hauptframe">{{ LNG.mu_global_message }}</a></li>{% endif %}
+		{% if allowedTo('ShowPassEncripterPage') %}<li><a href="?page=password" target="Hauptframe">{{ LNG.mu_md5_encripter }}</a></li>{% endif %}
+		{% if allowedTo('ShowStatUpdatePage') %}<li><a href="?page=statsupdate" target="Hauptframe" onClick=" return confirm('{{ LNG.mu_mpu_confirmation }}');">{{ LNG.mu_manual_points_update }}</a></li>{% endif %}
+		{% if allowedTo('ShowClearCachePage') %}<li><a href="?page=clearcache" target="Hauptframe">{{ LNG.mu_clear_cache }}</a></li>{% endif %}
 		<li style="background-image: url('./styles/theme/gow/img/menu-foot.png');height:30px;"></li>
 	</ul>
 </div>


### PR DESCRIPTION
Add missing closing parentheses to `allowedTo()` function calls in Twig `if` statements to fix syntax errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5ba71ee-f155-43a2-bb8b-a214b33d0585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5ba71ee-f155-43a2-bb8b-a214b33d0585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

