### PR TITLE
Register allowedTo function in twig

### DIFF
--- a/includes/classes/class.template.php
+++ b/includes/classes/class.template.php
@@ -65,6 +65,12 @@ class template
 
 	private function addCustomFunctions(): void
 	{
+		// Register allowedTo function for Twig templates (for rights/permissions checking)
+		$this->twig->addFunction(new TwigFunction('allowedTo', function(string $right): bool {
+			global $USER;
+			return isset($USER['rights']) && is_array($USER['rights']) && in_array($right, $USER['rights']);
+		}));
+		
 		// Register isModuleAvailable function for Twig templates
 		$this->twig->addFunction(new TwigFunction('isModuleAvailable', function(int $moduleId): bool {
 			return isModuleAvailable($moduleId);


### PR DESCRIPTION
Register `allowedTo()` Twig function to resolve template errors where the function was previously undefined.

The `ShowMenuPage.twig` template was calling `allowedTo()` which was not registered in the Twig environment, leading to errors. This change adds the function, restoring the functionality previously available with Smarty templates.

---
<a href="https://cursor.com/background-agent?bcId=bc-58e5a7dc-50c0-416f-b112-41b2d55eca3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58e5a7dc-50c0-416f-b112-41b2d55eca3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

