### PR TITLE
Update twig templates from smarty format

### DIFF
--- a/styles/templates/adm/UniversePage.twig
+++ b/styles/templates/adm/UniversePage.twig
@@ -13,15 +13,15 @@
 	{% for uniID, uniRow in uniList %}
 	<tr style="height:23px;">
 		<td>{{ uniID }}</td>
-		<td>{{ uniRow.uni_name|number_format(0, '.', ',')_format }}</td>
+		<td>{{ uniRow.uni_name }}</td>
 		<td>{(uniRow.game_speed / 2500)|number_format(0, '.', ',')}</td>
 		<td>{(uniRow.fleet_speed / 2500)|number_format(0, '.', ',')}</td>
-		<td>{{ uniRow.resource_multiplier|number_format(0, '.', ',')_format }}</td>
-		<td>{{ uniRow.halt_speed|number_format(0, '.', ',')_format }}</td>
-		<td>{{ uniRow.energySpeed|number_format(0, '.', ',')_format }}</td>
-		<td>{{ uniRow.users_amount|number_format(0, '.', ',')_format }}</td>
-		<td>{{ uniRow.planet|number_format(0, '.', ',')_format }}</td>
-		<td>{{ uniRow.inactive|number_format(0, '.', ',')_format }}</td>
+		<td>{{ uniRow.resource_multiplier|number_format(0, '.', ',') }}</td>
+		<td>{{ uniRow.halt_speed|number_format(0, '.', ',') }}</td>
+		<td>{{ uniRow.energySpeed|number_format(0, '.', ',') }}</td>
+		<td>{{ uniRow.users_amount|number_format(0, '.', ',') }}</td>
+		<td>{{ uniRow.planet|number_format(0, '.', ',') }}</td>
+		<td>{{ uniRow.inactive|number_format(0, '.', ',') }}</td>
 		<td>{% if uniRow.game_disable == 1 %}<span style="color:lime;">{{ LNG.uvs_on }}</span>{% else %}<span style="color:red;">{{ LNG.uvs_off }}</span>{% endif %}</td>
 		<td>{% if uniRow.game_disable == 1 %}<a href="?page=universe&amp;action=closed&amp;uniID={{ uniID }}&amp;sid={{ SID }}&amp;reload=t"><img src="styles/resource/images/icons/closed.png" alt=""></a>{% else %}<a href="?page=universe&amp;action=open&amp;uniID={{ uniID }}&amp;sid={{ SID }}&amp;reload=t"><img src="styles/resource/images/icons/open.png" alt=""></a>{% endif %}{% if uniID != constant('ROOT_UNI') %}<a href="?page=universe&amp;action=delete&amp;uniID={{ uniID }}&amp;sid={{ SID }}&amp;reload=t" onclick="return confirm('{{ LNG.uvs_delete }}');" title="{{ LNG.uvs_delete }}"><img src="styles/resource/images/false.png" alt=""></a>{% endif %}</td>
 	</tr>

--- a/styles/templates/game/page.empire.default.twig
+++ b/styles/templates/game/page.empire.default.twig
@@ -47,7 +47,7 @@
 					<td>{{ LNG.tech[elementID] }}</td>
 					<td class="res_{{ elementID }}_text">{array_sum(resourceArray)|number_format(0, '.', ',')}</td>
 					{% for planetID, resource in resourceArray %}
-						<td class="res_{{ elementID }}_text">{{ resource|number_format(0, '.', ',')_format }}</td>
+						<td class="res_{{ elementID }}_text">{{ resource|number_format(0, '.', ',') }}</td>
 					{% endfor %}
 				</tr>
 				{% endfor %}
@@ -59,7 +59,7 @@
 					<td>{{ LNG.tech[elementID] }}</td>
 					<td>{array_sum(buildArray)|number_format(0, '.', ',')}</td>
 					{% for planetID, build in buildArray %}
-						<td>{{ build|number_format(0, '.', ',')_format }}</td>
+						<td>{{ build|number_format(0, '.', ',') }}</td>
 					{% endfor %}
 				</tr>
 				{% endfor %}
@@ -69,9 +69,9 @@
 				{% for elementID, tech in planetList.tech %}
 				<tr>
 					<td>{{ LNG.tech[elementID] }}</td>
-					<td>{{ tech|number_format(0, '.', ',')_format }}</td>
+					<td>{{ tech|number_format(0, '.', ',') }}</td>
 					{% for name in planetList.name %}
-						<td>{{ tech|number_format(0, '.', ',')_format }}</td>
+						<td>{{ tech|number_format(0, '.', ',') }}</td>
 					{% endfor %}
 				</tr>
 				{% endfor %}
@@ -83,7 +83,7 @@
 					<td>{{ LNG.tech[elementID] }}</td>
 					<td>{array_sum(fleetArray)|number_format(0, '.', ',')}</td>
 					{% for planetID, fleet in fleetArray %}
-						<td>{{ fleet|number_format(0, '.', ',')_format }}</td>
+						<td>{{ fleet|number_format(0, '.', ',') }}</td>
 					{% endfor %}
 				</tr>
 				{% endfor %}
@@ -95,7 +95,7 @@
 					<td>{{ LNG.tech[elementID] }}</td>
 					<td>{array_sum(fleetArray)|number_format(0, '.', ',')}</td>
 					{% for planetID, fleet in fleetArray %}
-						<td>{{ fleet|number_format(0, '.', ',')_format }}</td>
+						<td>{{ fleet|number_format(0, '.', ',') }}</td>
 					{% endfor %}
 				</tr>
 				{% endfor %}


### PR DESCRIPTION
Remove incorrect `_format` suffixes from Twig `number_format` filter calls.

These were Smarty-like syntax remnants causing incorrect rendering or potential errors. The PR corrects these syntax errors to `{{ variable|number_format(...) }}`. Additionally, one instance of `uniRow.uni_name` was unnecessarily formatted and has been simplified.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ef9bc04-ec25-40ab-b458-4f6408542962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ef9bc04-ec25-40ab-b458-4f6408542962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

