### PR TITLE
Fix mysqli escape string type error

### DIFF
--- a/includes/classes/Database_BC.class.php
+++ b/includes/classes/Database_BC.class.php
@@ -155,7 +155,14 @@ class Database_BC extends mysqli
 
     public function sql_escape($string, $flag = false)
     {
-        return ($flag === false) ? parent::escape_string($string) : addcslashes(parent::escape_string($string), '%_');
+        // Ab PHP 8.3 darf nur ein String übergeben werden -> sicherstellen
+        if (!is_string($string)) {
+            $string = (string) $string;
+        }
+
+        return ($flag === false) 
+            ? parent::escape_string($string) 
+            : addcslashes(parent::escape_string($string), '%_');
     }
 
     public function str_correction($str)


### PR DESCRIPTION
Fix `mysqli::escape_string()` type error in `sql_escape` by casting non-string inputs to string for PHP 8.3+ compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-8acf2cc8-647e-4abe-ae84-d0f4ee36a804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8acf2cc8-647e-4abe-ae84-d0f4ee36a804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

