### PR TITLE
Implement twig cache clearing method

### DIFF
--- a/includes/classes/class.template.php
+++ b/includes/classes/class.template.php
@@ -304,4 +304,22 @@ class template
 	{
 		return CACHE_PATH . 'twig/';
 	}
+	
+	public function clearAllCache(): void
+	{
+		$cacheDir = ROOT_PATH . 'cache/twig';
+		if (!is_dir($cacheDir)) {
+			return;
+		}
+
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($cacheDir, RecursiveDirectoryIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ($files as $fileinfo) {
+			$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+			$todo($fileinfo->getRealPath());
+		}
+	}
 }


### PR DESCRIPTION
Add `clearAllCache()` method to the `template` class to fix a "Call to undefined method" error when clearing the Twig cache in the admin panel.

The `clearAllCache()` method was present in the previous Smarty-based template system. With the transition to Twig, this method was missing, causing a fatal error when the admin panel attempted to clear the cache. This PR re-introduces the method, adapted to recursively clear the `/cache/twig` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d83195a-5870-4396-8ca1-cb89c34c33c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d83195a-5870-4396-8ca1-cb89c34c33c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

