### PR TITLE
Fix memory usage function arguments

### DIFF
--- a/includes/classes/class.statbuilder.php
+++ b/includes/classes/class.statbuilder.php
@@ -28,7 +28,7 @@ class statbuilder
 	function __construct()
 	{
 		$this->starttime   	= microtime(true);
-		$this->memory		= array(round(memory_get_usage() / 1024,1),round(memory_get_usage(1) / 1024,1));
+		$this->memory		= array(round(memory_get_usage() / 1024,1),round(memory_get_usage(true) / 1024,1));
 		$this->time   		= TIMESTAMP;
 
 		$this->recordData  	= array();
@@ -46,9 +46,9 @@ class statbuilder
 		return array(
 			'stats_time'		=> $this->time,
 			'totaltime'    		=> round(microtime(true) - $this->starttime, 7),
-			'memory_peak'		=> array(round(memory_get_peak_usage() / 1024,1), round(memory_get_peak_usage(1) / 1024,1)),
+			'memory_peak'		=> array(round(memory_get_peak_usage() / 1024,1), round(memory_get_peak_usage(true) / 1024,1)),
 			'initial_memory'	=> $this->memory,
-			'end_memory'		=> array(round(memory_get_usage() / 1024,1), round(memory_get_usage(1) / 1024,1)),
+			'end_memory'		=> array(round(memory_get_usage() / 1024,1), round(memory_get_usage(true) / 1024,1)),
 			'sql_count'			=> Database::get()->getQueryCounter(),
 		);
 	}


### PR DESCRIPTION
Update `memory_get_usage()` and `memory_get_peak_usage()` calls to use boolean arguments for PHP 8.1+ compatibility.

PHP 8.1 introduced a strict type check for the `$real_usage` argument of `memory_get_usage()` and `memory_get_peak_usage()`, requiring `bool` instead of `int` (0 or 1). This PR resolves the `TypeError: Argument #1 ($real_usage) must be of type bool, int given`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccc39ac5-ccfa-4e56-ad16-a863cdd07b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ccc39ac5-ccfa-4e56-ad16-a863cdd07b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

