### PR TITLE
Fix html rendering in system messages

### DIFF
--- a/styles/templates/adm/error_message_body.twig
+++ b/styles/templates/adm/error_message_body.twig
@@ -5,7 +5,7 @@
             <th>{{ fcm_info }}</th>
         </tr>
 		<tr>
-            <td>{{ mes }}</td>
+            <td>{{ mes|raw }}</td>
         </tr>
     </table>
 </div>

--- a/styles/templates/game/error.default.twig
+++ b/styles/templates/game/error.default.twig
@@ -11,7 +11,7 @@
 	<div>
 		<table style="width: 100%;">
 			<tr>
-				<td><p>{{ message }}</p>{% if redirectButtons %}<p>{% for button in redirectButtons %}<a href="{{ button.url }}"><button>{{ button.label }}</button></a>{% endfor %}</p>{% endif %}</td>
+				<td><p>{{ message|raw }}</p>{% if redirectButtons %}<p>{% for button in redirectButtons %}<a href="{{ button.url }}"><button>{{ button.label }}</button></a>{% endfor %}</p>{% endif %}</td>
 			</tr>
 		</table>
 	</div>

--- a/styles/templates/install/error_message_body.twig
+++ b/styles/templates/install/error_message_body.twig
@@ -5,7 +5,7 @@
 			<div id="lang" align="right">{{ LNG.intro_lang }}:&nbsp;<select id="lang" name="lang" onchange="document.location = '?lang='+$(this).val();">{% for key, value in Selector %}<option value="{{ key }}"{% if key == lang %} selected{% endif %}>{{ value }}</option>{% endfor %}</select></div>
 		<div id="main" align="left">
 			<h1>{{ fcm_info }}</h1>
-			{{ mes }}
+			{{ mes|raw }}
 			</div>
 		</div>
 	</td>

--- a/styles/templates/install/ins_step8error.twig
+++ b/styles/templates/install/ins_step8error.twig
@@ -3,7 +3,7 @@
 	<td colspan="2">
 		<div class="installcontent">
 			<div id="main" class="left">
-				<div class="fatalerror"><p>{{ message }}</p></div>
+				<div class="fatalerror"><p>{{ message|raw }}</p></div>
 				<div><p>
 					<a href="index.php?mode=install&step=7&amp;username={{ username }}&amp;email={{ mail }}"><button>{{ LNG.back }}</button></a>
 				</p></div>

--- a/styles/templates/login/error.default.twig
+++ b/styles/templates/login/error.default.twig
@@ -8,7 +8,7 @@
 			<div class="panel-body">
 				<table class="table519">
 					<tr>
-						<td><p>{{ message }}</p>{% if redirectButtons %}<p>{% for button in redirectButtons %}<a href="{{ button.url }}"><button class="btn btn-default">{{ button.label }}</button></a>{% endfor %}</p>{% endif %}</td>
+						<td><p>{{ message|raw }}</p>{% if redirectButtons %}<p>{% for button in redirectButtons %}<a href="{{ button.url }}"><button class="btn btn-default">{{ button.label }}</button></a>{% endfor %}</p>{% endif %}</td>
 					</tr>
 				</table>
 			</div>


### PR DESCRIPTION
Fixes system and admin messages to render HTML correctly instead of displaying tags as plain text.

System messages, such as those for stats updates or cache clearing, were displaying HTML tags like `<br>` literally due to Twig's autoescape feature. This PR applies the `|raw` filter to these controlled system outputs in relevant Twig templates, ensuring HTML is rendered as intended while maintaining XSS protection for user-generated content.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d59b732-ace6-4330-b549-dc9b66ff2005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d59b732-ace6-4330-b549-dc9b66ff2005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

