### PR TITLE
Fix timezone handling for PHP 8.3

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -146,10 +146,24 @@ function _date(string $format, mixed $time = null, ?string $toTimeZone = null, $
 		$date->setTimestamp($time);
 		
 		$time	-= $date->getOffset();
+		
+		// Normalize timezone string for PHP 8.3+
+		$timezoneString = $toTimeZone;
+		if (!is_string($timezoneString) || $timezoneString === '' || is_numeric($timezoneString)) {
+			$timezoneString = 'UTC';
+		} else {
+			$timezoneString = trim($timezoneString);
+		}
+		
 		try {
-			$date->setTimezone(new DateTimeZone($toTimeZone));
-		} catch (Exception $e) {
-			
+			$date->setTimezone(new DateTimeZone($timezoneString));
+		} catch (Throwable $e) {
+			// Fallback to UTC if timezone is invalid
+			try {
+				$date->setTimezone(new DateTimeZone('UTC'));
+			} catch (Throwable $e2) {
+				// This should never happen, but just in case
+			}
 		}
 		$time	+= $date->getOffset();
 	}

--- a/includes/pages/game/AbstractGamePage.class.php
+++ b/includes/pages/game/AbstractGamePage.class.php
@@ -168,6 +168,36 @@ abstract class AbstractGamePage
 		));
 	}
 
+	/**
+	 * Resolves a timezone value to a valid timezone string for DateTimeZone.
+	 * Handles invalid values (numeric, empty, invalid) by falling back to UTC.
+	 * 
+	 * @param mixed $userTz The user timezone value to resolve
+	 * @param mixed $configTz The config timezone value as fallback
+	 * @return string A valid timezone string
+	 */
+	private function resolveTimezoneString($userTz, $configTz = 'UTC'): string
+	{
+		// Priority: userTz -> configTz -> 'UTC'
+		$tz = $userTz ?? $configTz ?? 'UTC';
+		
+		// Reject numeric, empty, or non-string values
+		if (!is_string($tz) || $tz === '' || is_numeric($tz)) {
+			return 'UTC';
+		}
+		
+		// Clean and validate
+		$tz = trim($tz);
+		
+		// Try to validate by attempting to create DateTimeZone
+		try {
+			new DateTimeZone($tz);
+			return $tz;
+		} catch (Throwable $e) {
+			return 'UTC';
+		}
+	}
+
 	protected function getPageData()
 	{
 		global $USER, $THEME;
@@ -177,18 +207,22 @@ abstract class AbstractGamePage
 			$this->getCronjobsTodo();
 		}
 
+		$config	= Config::get();
+		
 		$dateTimeServer		= new DateTime("now");
-		if(isset($USER['timezone'])) {
-			try {
-				$dateTimeUser	= new DateTime("now", new DateTimeZone($USER['timezone']));
-			} catch (Exception $e) {
-				$dateTimeUser	= $dateTimeServer;
-			}
-		} else {
+		
+		// Resolve timezone with robust handling for PHP 8.3+
+		$timezoneString = $this->resolveTimezoneString(
+			$USER['timezone'] ?? null,
+			$config->timezone ?? 'UTC'
+		);
+		
+		try {
+			$dateTimeUser	= new DateTime("now", new DateTimeZone($timezoneString));
+		} catch (Throwable $e) {
+			// Ultimate fallback: use server time if timezone creation still fails
 			$dateTimeUser	= $dateTimeServer;
 		}
-
-		$config	= Config::get();
 
 		$this->assign(array(
 			'vmode'				=> $USER['urlaubs_modus'],


### PR DESCRIPTION
Fixes PHP 8.3 `DateTimeZone::__construct()` error by ensuring a valid timezone string is always passed with robust fallbacks.

PHP 8.3 strictly requires a valid string for `DateTimeZone::__construct()`. Previously, `$USER['timezone']` or other configuration sources could be numeric, empty, or invalid, leading to a fatal error. This PR normalizes timezone values, falling back to 'UTC' if the provided value is invalid.

---
<a href="https://cursor.com/background-agent?bcId=bc-bca889f4-3845-428f-abde-6f6121221ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bca889f4-3845-428f-abde-6f6121221ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

