### PR TITLE
Render html and entities in admin

### DIFF
--- a/styles/templates/adm/AccountDataPageDetail.twig
+++ b/styles/templates/adm/AccountDataPageDetail.twig
@@ -93,7 +93,7 @@ border:0px;background:url(./styles/resource/images/admin/blank.gif);text-align:r
 			</div>
 		</td>
 	</tr><tr>
-		<td class="unico transparent">{{ AllianceHave }}</td>
+		<td class="unico transparent">{{ AllianceHave|raw }}</td>
 	</tr><tr>
 		<td class="unico transparent">
 			<div id="alianza" style="display:none">
@@ -178,7 +178,7 @@ border:0px;background:url(./styles/resource/images/admin/blank.gif);text-align:r
 				<th>{{ ac_temperature }}</th>
 				{% if canedit == 1 %}<th>{{ se_search_edit }}</th>{% endif %}
 			</tr>
-				{{ planets_moons }}
+				{{ planets_moons|raw }}
 			</table>
 			<br>
 			</div>

--- a/styles/templates/adm/SearchPage.twig
+++ b/styles/templates/adm/SearchPage.twig
@@ -82,11 +82,11 @@
 </div>
 <br>
 <table width="90%" border="0px">
-{{ PAGES }}
+{{ PAGES|raw }}
 </table>
-{{ LIST }}
+{{ LIST|raw }}
 <br>
 <table width="90%" border="0px">
-{{ PAGES }}
+{{ PAGES|raw }}
 </table>
 </form>


### PR DESCRIPTION
Apply Twig `|raw` filter to pre-formatted HTML strings and language strings in admin templates to correctly render HTML and entities.

Previously, HTML content and entities in these variables were displayed as plain text due to Twig's default escaping, leading to display issues in admin pages like the planet list and user overview.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c60f206-21a9-47c2-919e-5074c57a8cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c60f206-21a9-47c2-919e-5074c57a8cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

