### PR TITLE
Fix extra parenthesis in MultiIPs.twig

### DIFF
--- a/styles/templates/adm/MultiIPs.twig
+++ b/styles/templates/adm/MultiIPs.twig
@@ -11,7 +11,7 @@
 	</tr>
 	{% for IP, Users in multiGroups %}
 	<tr>
-		<td rowspan="{{ Users|length) }}">{{ IP }}</td>
+		<td rowspan="{{ Users|length }}">{{ IP }}</td>
 		{% for ID, User in Users %}
 		<td class="left" style="padding:3px;">{{ ID }}</td>
 		<td class="left" style="padding:3px;"><a href="admin.php?page=accountdata&id_u={{ ID }}">{{ User.username }} (?)</a></td>


### PR DESCRIPTION
Remove an extra closing parenthesis in `styles/templates/adm/MultiIPs.twig` line 14 to fix a Twig syntax error.

The error "Unexpected ')'" occurred because Twig does not allow unnecessary parentheses in filter expressions like `{{ Users|length) }}`. Removing the extra `)` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdf0b331-28c6-488d-a55c-7fe56acd6b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdf0b331-28c6-488d-a55c-7fe56acd6b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

