### PR TITLE
Fix message list loading with twig

### DIFF
--- a/includes/pages/game/ShowMessagesPage.class.php
+++ b/includes/pages/game/ShowMessagesPage.class.php
@@ -143,7 +143,7 @@ class ShowMessagesPage extends AbstractGamePage
             'maxPage'		=> $maxPage,
         ));
 
-        $this->display('page.messages.view.tpl');
+        $this->display('page.messages.view.twig');
     }
 
 
@@ -361,7 +361,7 @@ class ShowMessagesPage extends AbstractGamePage
             'OwnerRecord'	=> $receiverRecord,
         ));
 
-        $this->display('page.messages.write.tpl');
+        $this->display('page.messages.write.twig');
     }
 
     function show()
@@ -428,6 +428,6 @@ class ShowMessagesPage extends AbstractGamePage
             'side'			=> $side,
         ));
 
-        $this->display('page.messages.default.tpl');
+        $this->display('page.messages.default.twig');
     }
 }

--- a/styles/templates/game/page.messages.view.twig
+++ b/styles/templates/game/page.messages.view.twig
@@ -1,4 +1,4 @@
-{% extends "layout.full.twig" %}
+{% extends "layout.ajax.twig" %}
 
 {% block content %}
 <form action="game.php?page=messages" method="post">
@@ -46,13 +46,13 @@
 		<td>{{ Message.from }}</td>
 		<td>{{ Message.subject }}
 		{% if Message.type == 1 and MessID != 999 %}
-		<a href="#" onclick="return Dialog.PM({{ Message.sender }}, Message.CreateAnswer('{{ Message.subject }}'));" title="{{ LNG.mg_answer_to }} {{ strip_tags(Message.from) }}"><i class="far fa-envelope" title="Message privé" style="font-size: 15px;"></i></a>
+		<a href="#" onclick="return Dialog.PM({{ Message.sender }}, Message.CreateAnswer('{{ Message.subject }}'));" title="{{ LNG.mg_answer_to }} {{ Message.from|striptags }}"><i class="far fa-envelope" title="Message privé" style="font-size: 15px;"></i></a>
 		{% endif %}
 		</td>
 	</tr>
 	<tr class="messages_body">
 		<td colspan="3" class="left" style="padding: 10px; background: rgba(0,0,0,0.7);">
-		{{ Message.text }}
+		{{ Message.text|raw }}
 		</td>
 	</tr>
 	{% endfor %}


### PR DESCRIPTION
Restore message list loading in Ajax by updating template references, using the correct AJAX layout, and fixing Twig syntax.

The message list failed to load because `ShowMessagesPage.class.php` referenced old `.tpl` files instead of `.twig`, `page.messages.view.twig` extended the wrong layout for AJAX requests, and the template contained PHP `strip_tags()` calls and improperly escaped HTML in message content.

---
<a href="https://cursor.com/background-agent?bcId=bc-4250ecf3-ab67-47e7-a5d3-10ecfde32e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4250ecf3-ab67-47e7-a5d3-10ecfde32e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

