### PR TITLE
Apply raw filter to message templates

### DIFF
--- a/styles/templates/game/page.messages.view.twig
+++ b/styles/templates/game/page.messages.view.twig
@@ -43,8 +43,8 @@
 		{% if MessID != 999 %}<input name="messageID[{{ Message.id }}]" value="1" type="checkbox">{% endif %}
 		</td>
 		<td>{{ Message.time }}</td>
-		<td>{{ Message.from }}</td>
-		<td>{{ Message.subject }}
+		<td>{{ Message.from|raw }}</td>
+		<td>{{ Message.subject|raw }}
 		{% if Message.type == 1 and MessID != 999 %}
 		<a href="#" onclick="return Dialog.PM({{ Message.sender }}, Message.CreateAnswer('{{ Message.subject }}'));" title="{{ LNG.mg_answer_to }} {{ Message.from|striptags }}"><i class="far fa-envelope" title="Message privé" style="font-size: 15px;"></i></a>
 		{% endif %}


### PR DESCRIPTION
Add `|raw` filter to `Message.from` and `Message.subject` to correctly render HTML tags in message displays.

---
<a href="https://cursor.com/background-agent?bcId=bc-81abad72-b2b3-4af7-9e0d-4bb66a6d3fdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81abad72-b2b3-4af7-9e0d-4bb66a6d3fdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

