### PR TITLE
Fix strlen calls with non-string types

### DIFF
--- a/includes/pages/game/ShowShipyardPage.class.php
+++ b/includes/pages/game/ShowShipyardPage.class.php
@@ -262,7 +262,7 @@ class ShowShipyardPage extends AbstractGamePage
 			'elementList'	=> $elementList,
 			'NotBuilding'	=> $NotBuilding,
 			'BuildList'		=> $buildList,
-			'maxlength'		=> strlen(Config::get()->max_fleet_per_build),
+			'maxlength'		=> strlen((string)Config::get()->max_fleet_per_build),
 			'mode'			=> $mode,
 		));
 


### PR DESCRIPTION
Cast `Config::get()->max_fleet_per_build` to string before passing to `strlen()` to prevent a PHP 8.3 TypeError.

PHP 8.3 introduced stricter type checking for `strlen()`, requiring a string argument. Previously, a numeric value (double/float) from `Config::get()->max_fleet_per_build` was implicitly converted, which is no longer allowed.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a95a8d3-420a-4e96-bb4a-3bed96efcfcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a95a8d3-420a-4e96-bb4a-3bed96efcfcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

