### PR TITLE
Fix php 8.3 round() string error in shipyard

### DIFF
--- a/includes/pages/game/ShowShipyardPage.class.php
+++ b/includes/pages/game/ShowShipyardPage.class.php
@@ -90,9 +90,9 @@ class ShowShipyardPage extends AbstractGamePage
 				continue;
 			}
 			
-			$MaxElements 	= BuildFunctions::getMaxConstructibleElements($USER, $PLANET, $Element);
-			$Count			= is_numeric($Count) ? round($Count) : 0;
-			$Count 			= max(min($Count, Config::get()->max_fleet_per_build), 0);
+		$MaxElements 	= BuildFunctions::getMaxConstructibleElements($USER, $PLANET, $Element);
+		$Count			= is_numeric($Count) ? round((float)$Count) : 0;
+		$Count 			= max(min($Count, Config::get()->max_fleet_per_build), 0);
 			$Count 			= min($Count, $MaxElements);
 			
 			$BuildArray    	= !empty($PLANET['b_hangar_id']) ? unserialize($PLANET['b_hangar_id']) : array();


### PR DESCRIPTION
Cast string values to float before passing them to `round()` to ensure PHP 8.3 compatibility.

PHP 8.3 introduced stricter type checking for mathematical functions like `round()`, which now explicitly requires `int` or `float` arguments. This PR ensures the `$Count` variable, which originates from user input (strings), is correctly cast before being used by `round()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bae5c3b2-2ceb-4cf8-a3bd-fb68261cc091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bae5c3b2-2ceb-4cf8-a3bd-fb68261cc091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

