### PR TITLE
Fix undefined module constants and secure twig checks

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -159,7 +159,7 @@ define('AUTH_MOD'					, 1);
 define('AUTH_USR'					, 0);
 
 // Modules
-define('MODULE_AMOUNT'				, 43);
+define('MODULE_AMOUNT'				, 45);
 define('MODULE_ALLIANCE'			, 0);
 define('MODULE_BANLIST'				, 21);
 define('MODULE_BANNER'				, 37);
@@ -188,6 +188,8 @@ define('MODULE_MISSION_SPY'			, 24);
 define('MODULE_MISSION_STATION'		, 36);
 define('MODULE_MISSION_TRANSPORT'	, 34);
 define('MODULE_NOTICE'				, 17);
+define('MODULE_NOTES'				, 43);
+define('MODULE_SETTINGS'			, 44);
 define('MODULE_OFFICIER'			, 18);
 define('MODULE_PHALANX'				, 19);
 define('MODULE_PLAYERCARD'			, 20);

--- a/styles/templates/game/layout.responsive.twig
+++ b/styles/templates/game/layout.responsive.twig
@@ -90,42 +90,42 @@
 					<a href="game.php?page=overview" class="nav-link{% if GET.page|default('overview') == 'overview' %} active{% endif %}">
 						<i class="fas fa-home"></i> {{ LNG.lm_overview }}
 					</a>
-					{% if isModuleAvailable(constant('MODULE_BUILDING')) %}
+					{% if constant('MODULE_BUILDING') is defined and isModuleAvailable(constant('MODULE_BUILDING')) %}
 					<a href="game.php?page=buildings" class="nav-link{% if GET.page|default('') == 'buildings' %} active{% endif %}">
 						<i class="fas fa-city"></i> {{ LNG.lm_buildings }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_RESEARCH')) %}
+					{% if constant('MODULE_RESEARCH') is defined and isModuleAvailable(constant('MODULE_RESEARCH')) %}
 					<a href="game.php?page=research" class="nav-link{% if GET.page|default('') == 'research' %} active{% endif %}">
 						<i class="fas fa-flask"></i> {{ LNG.lm_research }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_SHIPYARD_FLEET')) %}
+					{% if constant('MODULE_SHIPYARD_FLEET') is defined and isModuleAvailable(constant('MODULE_SHIPYARD_FLEET')) %}
 					<a href="game.php?page=shipyard&mode=fleet" class="nav-link{% if GET.page|default('') == 'shipyard' and GET.mode|default('') == 'fleet' %} active{% endif %}">
 						<i class="fas fa-rocket"></i> {{ LNG.lm_shipshard }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_SHIPYARD_DEFENSIVE')) %}
+					{% if constant('MODULE_SHIPYARD_DEFENSIVE') is defined and isModuleAvailable(constant('MODULE_SHIPYARD_DEFENSIVE')) %}
 					<a href="game.php?page=shipyard&mode=defense" class="nav-link{% if GET.page|default('') == 'shipyard' and GET.mode|default('') == 'defense' %} active{% endif %}">
 						<i class="fas fa-shield-alt"></i> {{ LNG.lm_defenses }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_OFFICIER')) %}
+					{% if constant('MODULE_OFFICIER') is defined and isModuleAvailable(constant('MODULE_OFFICIER')) %}
 					<a href="game.php?page=officier" class="nav-link{% if GET.page|default('') == 'officier' %} active{% endif %}">
 						<i class="fas fa-user-tie"></i> {{ LNG.lm_officiers }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_GALAXY')) %}
+					{% if constant('MODULE_GALAXY') is defined and isModuleAvailable(constant('MODULE_GALAXY')) %}
 					<a href="game.php?page=galaxy" class="nav-link{% if GET.page|default('') == 'galaxy' %} active{% endif %}">
 						<i class="fas fa-globe"></i> {{ LNG.lm_galaxy }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_FLEET_TRADER')) %}
+					{% if constant('MODULE_FLEET_TRADER') is defined and isModuleAvailable(constant('MODULE_FLEET_TRADER')) %}
 					<a href="game.php?page=fleetTable" class="nav-link{% if GET.page|default('') == 'fleetTable' %} active{% endif %}">
 						<i class="fas fa-space-shuttle"></i> {{ LNG.lm_fleet }}
 					</a>
 					{% endif %}
-					{% if isModuleAvailable(constant('MODULE_ALLIANCE')) %}
+					{% if constant('MODULE_ALLIANCE') is defined and isModuleAvailable(constant('MODULE_ALLIANCE')) %}
 					<a href="game.php?page=alliance" class="nav-link{% if GET.page|default('') == 'alliance' %} active{% endif %}">
 						<i class="fas fa-users"></i> {{ LNG.lm_alliance }}
 					</a>
@@ -141,43 +141,43 @@
 							<i class="fas fa-chevron-down"></i>
 						</button>
 						<div class="dropdown-content">
-							{% if isModuleAvailable(constant('MODULE_MESSAGES')) %}
+							{% if constant('MODULE_MESSAGES') is defined and isModuleAvailable(constant('MODULE_MESSAGES')) %}
 							<a href="game.php?page=messages">
 								<i class="fas fa-envelope"></i> {{ LNG.lm_messages }}
 								{% if new_message > 0 %}<span class="badge">{{ new_message }}</span>{% endif %}
 							</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_CHAT')) %}
+							{% if constant('MODULE_CHAT') is defined and isModuleAvailable(constant('MODULE_CHAT')) %}
 							<a href="game.php?page=chat"><i class="fas fa-comment-dots"></i> {{ LNG.lm_chat }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_STATISTICS')) %}
+							{% if constant('MODULE_STATISTICS') is defined and isModuleAvailable(constant('MODULE_STATISTICS')) %}
 							<a href="game.php?page=statistics"><i class="fas fa-chart-line"></i> {{ LNG.lm_statistics }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_RECORDS')) %}
+							{% if constant('MODULE_RECORDS') is defined and isModuleAvailable(constant('MODULE_RECORDS')) %}
 							<a href="game.php?page=records"><i class="fas fa-trophy"></i> {{ LNG.lm_records }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_BATTLEHALL')) %}
+							{% if constant('MODULE_BATTLEHALL') is defined and isModuleAvailable(constant('MODULE_BATTLEHALL')) %}
 							<a href="game.php?page=battleHall"><i class="fas fa-fist-raised"></i> {{ LNG.lm_topkb }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_BUDDYLIST')) %}
+							{% if constant('MODULE_BUDDYLIST') is defined and isModuleAvailable(constant('MODULE_BUDDYLIST')) %}
 							<a href="game.php?page=buddyList"><i class="fas fa-user-friends"></i> {{ LNG.lm_buddylist }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_BANLIST')) %}
+							{% if constant('MODULE_BANLIST') is defined and isModuleAvailable(constant('MODULE_BANLIST')) %}
 							<a href="game.php?page=banList"><i class="fas fa-ban"></i> {{ LNG.lm_banned }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_NOTES')) %}
+							{% if constant('MODULE_NOTES') is defined and isModuleAvailable(constant('MODULE_NOTES')) %}
 							<a href="game.php?page=notes"><i class="fas fa-sticky-note"></i> {{ LNG.lm_notes }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_SIMULATOR')) %}
+							{% if constant('MODULE_SIMULATOR') is defined and isModuleAvailable(constant('MODULE_SIMULATOR')) %}
 							<a href="game.php?page=battleSimulator"><i class="fas fa-crosshairs"></i> {{ LNG.lm_battlesim }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_TRADER')) %}
+							{% if constant('MODULE_TRADER') is defined and isModuleAvailable(constant('MODULE_TRADER')) %}
 							<a href="game.php?page=fleetDealer"><i class="fas fa-store"></i> {{ LNG.lm_fleettrader }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_RESSOURCE_LIST')) %}
+							{% if constant('MODULE_RESSOURCE_LIST') is defined and isModuleAvailable(constant('MODULE_RESSOURCE_LIST')) %}
 							<a href="game.php?page=resources"><i class="fas fa-chart-bar"></i> {{ LNG.lm_resources }}</a>
 							{% endif %}
-							{% if isModuleAvailable(constant('MODULE_SUPPORT')) %}
+							{% if constant('MODULE_SUPPORT') is defined and isModuleAvailable(constant('MODULE_SUPPORT')) %}
 							<a href="game.php?page=ticket"><i class="fas fa-headset"></i> {{ LNG.lm_support }}</a>
 							{% endif %}
 							<a href="game.php?page=settings"><i class="fas fa-cog"></i> {{ LNG.lm_options }}</a>
@@ -234,54 +234,54 @@
 				<a href="game.php?page=overview" class="mobile-nav-item{% if GET.page|default('overview') == 'overview' %} active{% endif %}">
 					<i class="fas fa-home"></i> {{ LNG.lm_overview }}
 				</a>
-				{% if isModuleAvailable(constant('MODULE_BUILDING')) %}
+				{% if constant('MODULE_BUILDING') is defined and isModuleAvailable(constant('MODULE_BUILDING')) %}
 				<a href="game.php?page=buildings" class="mobile-nav-item{% if GET.page|default('') == 'buildings' %} active{% endif %}">
 					<i class="fas fa-city"></i> {{ LNG.lm_buildings }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_RESEARCH')) %}
+				{% if constant('MODULE_RESEARCH') is defined and isModuleAvailable(constant('MODULE_RESEARCH')) %}
 				<a href="game.php?page=research" class="mobile-nav-item{% if GET.page|default('') == 'research' %} active{% endif %}">
 					<i class="fas fa-flask"></i> {{ LNG.lm_research }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_SHIPYARD_FLEET')) %}
+				{% if constant('MODULE_SHIPYARD_FLEET') is defined and isModuleAvailable(constant('MODULE_SHIPYARD_FLEET')) %}
 				<a href="game.php?page=shipyard&mode=fleet" class="mobile-nav-item{% if GET.page|default('') == 'shipyard' and GET.mode|default('') == 'fleet' %} active{% endif %}">
 					<i class="fas fa-rocket"></i> {{ LNG.lm_shipshard }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_SHIPYARD_DEFENSIVE')) %}
+				{% if constant('MODULE_SHIPYARD_DEFENSIVE') is defined and isModuleAvailable(constant('MODULE_SHIPYARD_DEFENSIVE')) %}
 				<a href="game.php?page=shipyard&mode=defense" class="mobile-nav-item{% if GET.page|default('') == 'shipyard' and GET.mode|default('') == 'defense' %} active{% endif %}">
 					<i class="fas fa-shield-alt"></i> {{ LNG.lm_defenses }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_OFFICIER')) %}
+				{% if constant('MODULE_OFFICIER') is defined and isModuleAvailable(constant('MODULE_OFFICIER')) %}
 				<a href="game.php?page=officier" class="mobile-nav-item{% if GET.page|default('') == 'officier' %} active{% endif %}">
 					<i class="fas fa-user-tie"></i> {{ LNG.lm_officiers }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_GALAXY')) %}
+				{% if constant('MODULE_GALAXY') is defined and isModuleAvailable(constant('MODULE_GALAXY')) %}
 				<a href="game.php?page=galaxy" class="mobile-nav-item{% if GET.page|default('') == 'galaxy' %} active{% endif %}">
 					<i class="fas fa-globe"></i> {{ LNG.lm_galaxy }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_FLEET_TRADER')) %}
+				{% if constant('MODULE_FLEET_TRADER') is defined and isModuleAvailable(constant('MODULE_FLEET_TRADER')) %}
 				<a href="game.php?page=fleetTable" class="mobile-nav-item{% if GET.page|default('') == 'fleetTable' %} active{% endif %}">
 					<i class="fas fa-space-shuttle"></i> {{ LNG.lm_fleet }}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_ALLIANCE')) %}
+				{% if constant('MODULE_ALLIANCE') is defined and isModuleAvailable(constant('MODULE_ALLIANCE')) %}
 				<a href="game.php?page=alliance" class="mobile-nav-item{% if GET.page|default('') == 'alliance' %} active{% endif %}">
 					<i class="fas fa-users"></i> {{ LNG.lm_alliance }}
 				</a>
 				{% endif %}
 				<div class="mobile-nav-divider"></div>
-				{% if isModuleAvailable(constant('MODULE_MESSAGES')) %}
+				{% if constant('MODULE_MESSAGES') is defined and isModuleAvailable(constant('MODULE_MESSAGES')) %}
 				<a href="game.php?page=messages" class="mobile-nav-item">
 					<i class="fas fa-envelope"></i> {{ LNG.lm_messages }}
 					{% if new_message > 0 %}<span class="badge">{{ new_message }}</span>{% endif %}
 				</a>
 				{% endif %}
-				{% if isModuleAvailable(constant('MODULE_STATISTICS')) %}
+				{% if constant('MODULE_STATISTICS') is defined and isModuleAvailable(constant('MODULE_STATISTICS')) %}
 				<a href="game.php?page=statistics" class="mobile-nav-item">
 					<i class="fas fa-chart-line"></i> {{ LNG.lm_statistics }}
 				</a>


### PR DESCRIPTION
Add missing `MODULE_*` constants and secure Twig checks to prevent "Undefined constant" errors and ensure module-dependent navigation displays correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbd1658d-226e-4cef-8197-e302aceb8d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbd1658d-226e-4cef-8197-e302aceb8d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

