### PR TITLE
Remove empty transparent header element

### DIFF
--- a/styles/css/main.css
+++ b/styles/css/main.css
@@ -1357,6 +1357,23 @@ tbody tr:nth-child(odd) {
   overflow: hidden;
 }
 
+/* Fix: Hide empty header-left elements and duplicate burger buttons */
+.header-left:empty,
+.menu-toggle:empty,
+#sidebar-toggle {
+  display: none !important;
+  background: none !important;
+  box-shadow: none !important;
+  border: none !important;
+}
+
+/* Ensure the correct burger button stays visible on mobile */
+@media (max-width: 992px) {
+  .burger-menu#burgerMenu {
+    display: flex !important;
+  }
+}
+
 .burger-menu span {
   display: block;
   width: 22px;

--- a/styles/resource/css/ingame/burger-menu-fix.css
+++ b/styles/resource/css/ingame/burger-menu-fix.css
@@ -8,9 +8,8 @@
    ============================================ */
 .burger-menu,
 #burgerMenu,
-#burger-toggle,
-#sidebar-toggle {
-    display: flex; /* Always visible for debugging, will be controlled by media queries */
+#burger-toggle {
+    display: none; /* Hidden by default, shown via media queries */
     position: relative;
     width: 40px;
     height: 40px;
@@ -27,10 +26,14 @@
     z-index: 10001;
 }
 
+/* Hide sidebar-toggle as it's redundant */
+#sidebar-toggle {
+    display: none !important;
+}
+
 .burger-menu:hover,
 #burgerMenu:hover,
-#burger-toggle:hover,
-#sidebar-toggle:hover {
+#burger-toggle:hover {
     background: rgba(0, 243, 255, 0.1);
     border-color: var(--color-accent-cyan, #00f3ff);
     transform: scale(1.05);
@@ -40,7 +43,6 @@
 .burger-menu span,
 #burgerMenu span,
 #burger-toggle span,
-#sidebar-toggle span,
 .burger-line {
     display: block;
     width: 24px;
@@ -53,23 +55,20 @@
 /* Active state animations */
 .burger-menu.active span:nth-child(1),
 #burgerMenu.active span:nth-child(1),
-#burger-toggle.active span:nth-child(1),
-#sidebar-toggle.active span:nth-child(1) {
+#burger-toggle.active span:nth-child(1) {
     transform: rotate(45deg) translateY(8px);
 }
 
 .burger-menu.active span:nth-child(2),
 #burgerMenu.active span:nth-child(2),
-#burger-toggle.active span:nth-child(2),
-#sidebar-toggle.active span:nth-child(2) {
+#burger-toggle.active span:nth-child(2) {
     opacity: 0;
     transform: translateX(-20px);
 }
 
 .burger-menu.active span:nth-child(3),
 #burgerMenu.active span:nth-child(3),
-#burger-toggle.active span:nth-child(3),
-#sidebar-toggle.active span:nth-child(3) {
+#burger-toggle.active span:nth-child(3) {
     transform: rotate(-45deg) translateY(-8px);
 }
 
@@ -235,6 +234,12 @@
    ============================================ */
 @media screen and (max-width: 992px) {
     /* Show burger menu */
+    .burger-menu,
+    #burgerMenu,
+    #burger-toggle {
+        display: flex !important;
+    }
+    
     /* Sidebar and overlay offset for mobile header height */
     .game-sidebar,
     #gameSidebar {

--- a/styles/resource/css/ingame/mobile-menu-enhanced.css
+++ b/styles/resource/css/ingame/mobile-menu-enhanced.css
@@ -171,8 +171,8 @@
 /* ============================================
    ENHANCED BURGER BUTTON
    ============================================ */
-.burger-menu,
-#sidebar-toggle {
+.burger-menu {
+  /* #sidebar-toggle removed - using #burgerMenu instead */
   display: none; /* Hidden by default */
   position: relative;
   width: 44px;
@@ -193,22 +193,22 @@
 
 /* Show on mobile */
 @media (max-width: 768px) {
-  .burger-menu,
-  #sidebar-toggle {
+  .burger-menu {
     display: flex !important;
   }
+  /* #sidebar-toggle removed */
 }
 
-.burger-menu:hover,
-#sidebar-toggle:hover {
+.burger-menu:hover {
+  /* #sidebar-toggle removed */
   background: rgba(0, 243, 255, 0.15);
   border-color: #00f3ff;
   transform: scale(1.05);
   box-shadow: 0 0 20px rgba(0, 243, 255, 0.6);
 }
 
-.burger-menu:active,
-#sidebar-toggle:active {
+.burger-menu:active {
+  /* #sidebar-toggle removed */
   transform: scale(0.95);
 }
 

--- a/styles/resource/css/ingame/mobile-navigation-fix.css
+++ b/styles/resource/css/ingame/mobile-navigation-fix.css
@@ -149,7 +149,7 @@
 /* ============================================
    BURGER MENU BUTTON ENHANCEMENTS
    ============================================ */
-#sidebar-toggle,
+/* #sidebar-toggle removed - using #burgerMenu instead */
 .burger-menu {
     position: relative !important;
     width: 44px !important;
@@ -170,13 +170,13 @@
 
 /* Show burger menu on mobile */
 @media (max-width: 768px) {
-    #sidebar-toggle,
+    /* #sidebar-toggle removed - using #burgerMenu instead */
     .burger-menu {
         display: flex !important;
     }
 }
 
-#sidebar-toggle:hover,
+/* #sidebar-toggle removed */
 .burger-menu:hover {
     background: rgba(0, 243, 255, 0.15) !important;
     border-color: #00f3ff !important;
@@ -184,7 +184,7 @@
     box-shadow: 0 0 15px rgba(0, 243, 255, 0.5) !important;
 }
 
-#sidebar-toggle:active,
+/* #sidebar-toggle removed */
 .burger-menu:active {
     transform: scale(0.95) !important;
 }
@@ -200,18 +200,18 @@
 }
 
 /* Active state animation */
-#sidebar-toggle.active .burger-line:nth-child(1),
+/* #sidebar-toggle removed */
 .burger-menu.active .burger-line:nth-child(1) {
     transform: rotate(45deg) translate(7px, 7px) !important;
 }
 
-#sidebar-toggle.active .burger-line:nth-child(2),
+/* #sidebar-toggle removed */
 .burger-menu.active .burger-line:nth-child(2) {
     opacity: 0 !important;
     transform: translateX(-10px) !important;
 }
 
-#sidebar-toggle.active .burger-line:nth-child(3),
+/* #sidebar-toggle removed */
 .burger-menu.active .burger-line:nth-child(3) {
     transform: rotate(-45deg) translate(7px, -7px) !important;
 }
@@ -353,7 +353,7 @@
 /* ============================================
    ACCESSIBILITY IMPROVEMENTS
    ============================================ */
-#sidebar-toggle:focus,
+/* #sidebar-toggle removed */
 .burger-menu:focus {
     outline: 3px solid #00f3ff !important;
     outline-offset: 2px !important;

--- a/styles/resource/css/ingame/sidebar-mobile.css
+++ b/styles/resource/css/ingame/sidebar-mobile.css
@@ -54,7 +54,7 @@
     }
     
     /* Hide burger button on desktop */
-    #sidebar-toggle,
+    /* #sidebar-toggle removed - using #burgerMenu instead */
     .burger-menu {
         display: none !important;
     }
@@ -92,7 +92,7 @@
     }
     
     /* Show burger button on mobile */
-    #sidebar-toggle,
+    /* #sidebar-toggle removed - using #burgerMenu instead */
     .burger-menu {
         display: flex !important;
     }
@@ -101,7 +101,7 @@
 /* ============================================
    BURGER BUTTON STYLES
    ============================================ */
-#sidebar-toggle,
+/* #sidebar-toggle removed - using #burgerMenu instead */
 .burger-menu {
     position: relative;
     width: 40px;
@@ -120,7 +120,7 @@
     margin-right: 10px;
 }
 
-#sidebar-toggle:hover,
+/* #sidebar-toggle removed */
 .burger-menu:hover {
     background: rgba(0, 243, 255, 0.1);
     border-color: var(--color-accent-cyan, #00f3ff);
@@ -137,17 +137,20 @@
 
 /* Burger animation when active */
 .burger-menu.active .burger-line:nth-child(1),
-#sidebar-toggle.active .burger-line:nth-child(1) {
+/* #sidebar-toggle removed */
+.burger-menu.active .burger-line:nth-child(1) {
     transform: rotate(45deg) translateY(8px);
 }
 
 .burger-menu.active .burger-line:nth-child(2),
-#sidebar-toggle.active .burger-line:nth-child(2) {
+/* #sidebar-toggle removed */
+.burger-menu.active .burger-line:nth-child(2) {
     opacity: 0;
 }
 
 .burger-menu.active .burger-line:nth-child(3),
-#sidebar-toggle.active .burger-line:nth-child(3) {
+/* #sidebar-toggle removed */
+.burger-menu.active .burger-line:nth-child(3) {
     transform: rotate(-45deg) translateY(-8px);
 }
 

--- a/styles/templates/game/main.navigation_header.twig
+++ b/styles/templates/game/main.navigation_header.twig
@@ -1,13 +1,9 @@
 <!-- SmartMoons Sci-Fi Header -->
 <div id="top-header" class="sci-fi-header">
 	<div class="header-container">
-		<!-- Left Section: Logo & Burger Menu -->
+		<!-- Left Section: Logo -->
 		<div class="header-left">
-			<button id="sidebar-toggle" class="burger-menu" aria-label="Toggle Menu">
-				<span class="burger-line"></span>
-				<span class="burger-line"></span>
-				<span class="burger-line"></span>
-			</button>
+			<!-- sidebar-toggle removed - using unified burgerMenu button instead -->
             <!-- Mobile Navigation Menu (populated from sidebar) -->
             <nav class="mobile-nav" id="mobile-nav" aria-hidden="true">
                 <ul>


### PR DESCRIPTION
Remove redundant `#sidebar-toggle` element and associated CSS to eliminate an empty, semi-transparent box in the header.

A duplicate `#sidebar-toggle` element from an older template was causing an unwanted, semi-transparent box to appear over the main burger menu. This PR removes the redundant element and cleans up related CSS to ensure only the intended burger menu is present and correctly styled, without impacting its functionality or appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fdfc477-49ea-4ee1-88c5-2cac5737e344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fdfc477-49ea-4ee1-88c5-2cac5737e344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

