### PR TITLE
Behebe leeren Block über Ressourcenleiste

### DIFF
--- a/styles/css/main.css
+++ b/styles/css/main.css
@@ -46,6 +46,15 @@
 /* =====================================================
    CORE DESIGN SYSTEM
    ===================================================== */
+
+/* Fix für störende halbtransparente Blöcke über Ressourcenleiste */
+.header::before,
+.topbar::before,
+.main-header::before,
+.header-bg,
+.nav-bg {
+  display: none !important;
+}
 body {
   background: 
     linear-gradient(135deg, #0a0a14 0%, #0f0820 25%, #0a0f1a 50%, #050712 100%),
@@ -227,8 +236,8 @@ header::after, .main-header::after {
   background: linear-gradient(135deg, 
     rgba(15, 20, 35, 0.6) 0%, 
     rgba(20, 25, 40, 0.5) 100%);
-  border-radius: 16px;
-  margin: 10px;
+  border-radius: 0 0 16px 16px; /* Rundung nur unten */
+  margin: 0; /* Kein Abstand - direkt am Header */
   padding: 8px 4px;
   box-shadow: 
     inset 0 2px 10px rgba(0, 234, 255, 0.1),
@@ -237,6 +246,7 @@ header::after, .main-header::after {
   backdrop-filter: blur(10px) saturate(120%);
   -webkit-backdrop-filter: blur(10px) saturate(120%);
   border: 1px solid rgba(0, 234, 255, 0.12);
+  border-top: none; /* Kein Rand oben - geht nahtlos in Header über */
   position: relative;
   overflow: hidden;
 }
@@ -758,7 +768,7 @@ header::after, .main-header::after {
    MAIN CONTENT - PURPLE ACCENT ZONE
    ===================================================== */
 .main-content {
-  padding-top: 100px; /* For fixed header + resource bar */
+  padding-top: 0; /* Kein Abstand - Resource Bar ist Teil des Headers */
   min-height: 100vh;
   position: relative;
   z-index: 1;
@@ -769,8 +779,10 @@ header::after, .main-header::after {
     rgba(167, 108, 255, 0.03) 100%);
 }
 
-/* Animated background particles */
+/* Animated background particles - DEAKTIVIERT um störenden Block zu entfernen */
 .main-content::before {
+  display: none !important;
+  /* Original-Code deaktiviert, da er den störenden halbtransparenten Block verursacht
   content: '';
   position: absolute;
   top: 0;
@@ -785,6 +797,7 @@ header::after, .main-header::after {
   animation: particleFloat 30s linear infinite;
   pointer-events: none;
   opacity: 0.4;
+  */
 }
 
 @keyframes particleFloat {
@@ -1039,10 +1052,11 @@ textarea:focus {
   
   .resource-bar {
     overflow-x: auto;
-    margin: 6px;
+    margin: 0; /* Kein Abstand - direkt am Header */
     padding: 6px 2px;
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 234, 255, 0.3) transparent;
+    border-radius: 0 0 12px 12px; /* Rundung nur unten auch auf Tablet */
   }
   
   .resource-bar::-webkit-scrollbar {
@@ -1060,7 +1074,7 @@ textarea:focus {
   }
   
   .main-content {
-    padding-top: 95px;
+    padding-top: 0; /* Kein Abstand auch auf Tablet */
   }
   
   .content-wrapper {
@@ -1102,8 +1116,9 @@ textarea:focus {
   }
   
   .resource-bar {
-    margin: 4px;
+    margin: 0; /* Kein Abstand auch auf Mobilgerät */
     padding: 4px 0;
+    border-radius: 0 0 10px 10px; /* Rundung nur unten auch auf Mobilgerät */
   }
   
   .resource-name {
@@ -1143,11 +1158,13 @@ textarea:focus {
 /* iPhone specific optimizations */
 @media (max-width: 390px) {
   .main-content {
-    padding-top: 85px;
+    padding-top: 0; /* Kein Abstand auch auf iPhone */
   }
   
   .resource-bar {
+    margin: 0; /* Kein Abstand auch auf kleinen Geräten */
     padding: 3px 0;
+    border-radius: 0 0 8px 8px; /* Rundung nur unten auch auf kleinen Geräten */
   }
   
   .footer-content {

--- a/styles/css/smartmoons-fix.css
+++ b/styles/css/smartmoons-fix.css
@@ -1,0 +1,93 @@
+/* =====================================================
+   SMARTMOONS FIX - BEHEBT RESSOURCENLEISTEN-PROBLEM
+   Entfernt störende halbtransparente Blöcke
+   ===================================================== */
+
+/* KRITISCHER FIX: Deaktiviert alle störenden Pseudo-Elemente und Hintergrundblöcke */
+.header::before,
+.header::after,
+.topbar::before,
+.topbar::after,
+.main-header::before,
+.header-bg,
+.nav-bg,
+.main-content::before,
+.main-content::after,
+.resource-bar::before {
+  display: none !important;
+  content: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+/* Header und Resource Bar nahtlos verbinden */
+.main-header {
+  position: sticky !important;
+  top: 0 !important;
+  border-bottom: none !important;
+  margin-bottom: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.resource-bar {
+  position: relative !important;
+  margin: 0 !important;
+  margin-top: 0 !important;
+  padding-top: 8px !important;
+  border-top: none !important;
+  /* Nahtloser Übergang vom Header */
+  background: linear-gradient(135deg, 
+    rgba(15, 20, 35, 0.8) 0%, 
+    rgba(20, 25, 40, 0.7) 100%) !important;
+}
+
+/* Main Content direkt unter Resource Bar */
+.main-content {
+  margin-top: 0 !important;
+  padding-top: 20px !important; /* Nur normaler Content-Padding */
+}
+
+/* App Container optimiert */
+.app-container {
+  display: flex !important;
+  flex-direction: column !important;
+  min-height: 100vh !important;
+}
+
+/* Stelle sicher, dass keine leeren Container sichtbar sind */
+div:empty:not([class]):not([id]),
+.header-bg,
+.nav-bg {
+  display: none !important;
+  height: 0 !important;
+  min-height: 0 !important;
+  max-height: 0 !important;
+}
+
+/* Mobile Anpassungen */
+@media (max-width: 992px) {
+  .resource-bar {
+    padding: 6px 2px !important;
+  }
+}
+
+@media (max-width: 600px) {
+  .resource-bar {
+    padding: 4px 0 !important;
+  }
+  
+  .main-content {
+    padding-top: 15px !important;
+  }
+}
+
+@media (max-width: 390px) {
+  .resource-bar {
+    padding: 3px 0 !important;
+  }
+  
+  .main-content {
+    padding-top: 10px !important;
+  }
+}

--- a/styles/templates/game/layout.responsive.twig
+++ b/styles/templates/game/layout.responsive.twig
@@ -13,6 +13,7 @@
 	<!-- Core Styles -->
 	<link rel="stylesheet" type="text/css" href="./styles/theme/smartmoons-unified.css?v={{ REV }}">
 	<link rel="stylesheet" type="text/css" href="./styles/css/main.css?v={{ REV }}">
+	<link rel="stylesheet" type="text/css" href="./styles/css/smartmoons-fix.css?v={{ REV }}">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 	<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;900&family=Rajdhani:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 	<link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">

--- a/styles/theme/smartmoons-unified.css
+++ b/styles/theme/smartmoons-unified.css
@@ -3,6 +3,16 @@
    Elegant futuristic design with glass morphism
    ===================================================== */
 
+/* KRITISCHER FIX: Entfernt störende halbtransparente Blöcke über Ressourcenleiste */
+.header::before,
+.topbar::before,
+.main-header::before,
+.header-bg,
+.nav-bg,
+.main-content::before {
+  display: none !important;
+}
+
 /* =====================================================
    1. CSS VARIABLES & ROOT
    ===================================================== */
@@ -143,7 +153,7 @@ a:hover {
    4. HEADER - FIXED DARK GLASS
    ===================================================== */
 .main-header {
-    position: fixed;
+    position: sticky; /* Geändert von fixed zu sticky - bleibt oben aber im Dokumentfluss */
     top: 0;
     left: 0;
     right: 0;
@@ -151,9 +161,10 @@ a:hover {
     background: var(--bg-glass);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border-bottom: var(--border-glass);
+    border-bottom: none; /* Border entfernt - Resource Bar schließt direkt an */
     z-index: var(--z-header);
-    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
+    box-shadow: none; /* Shadow nur an der Resource Bar für nahtlosen Übergang */
+    border-radius: 12px 12px 0 0; /* Rundung nur oben */
 }
 
 /* Header Content Layout */
@@ -583,22 +594,23 @@ a:hover {
    6. RESOURCE BAR - INTEGRATED WITH HEADER
    ===================================================== */
 .resource-bar {
-    position: fixed;
-    top: var(--header-height);
-    left: 0;
-    right: 0;
+    position: relative; /* Geändert von fixed zu relative - direkt im Header-Flow */
+    /* top, left, right entfernt - nicht benötigt bei relative Position */
     height: var(--resource-height);
     background: var(--bg-glass-light);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border-bottom: var(--border-glass);
+    border-top: none; /* Kein oberer Rand - nahtloser Übergang zum Header */
     display: flex;
     align-items: center;
     justify-content: center;
     gap: var(--gap-lg);
     padding: 0 var(--gap-lg);
+    margin: 0; /* Kein Abstand */
     z-index: var(--z-resource);
     box-shadow: 0 2px 15px rgba(0, 0, 0, 0.4);
+    border-radius: 0 0 12px 12px; /* Rundung nur unten */
 }
 
 .resource-item {
@@ -672,10 +684,10 @@ a:hover {
    ===================================================== */
 .main-content {
     flex: 1;
-    margin-top: var(--total-header);
+    margin-top: 0; /* Kein Abstand - Ressourcenleiste ist Teil des Headers */
     padding: var(--gap-lg);
     padding-bottom: calc(var(--footer-height) + var(--gap-lg));
-    min-height: calc(100vh - var(--total-header));
+    min-height: 100vh; /* Volle Höhe ohne Header-Abzug */
     position: relative;
 }
 


### PR DESCRIPTION
Removes a semi-transparent overlay block and aligns the resource bar directly under the header to fix a visual layout issue.

Previously, a semi-transparent block appeared behind the rocket icon and above the resource bar on build and research pages, causing the resource bar to be visually shifted downwards. This PR disables the responsible pseudo-elements and adjusts CSS properties to ensure the resource bar is flush with the header, maintaining the intended clear, dark blue aesthetic without any overlays or misalignments.

---
<a href="https://cursor.com/background-agent?bcId=bc-de9e12d9-d746-4fbe-a8ec-14b43ef257c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de9e12d9-d746-4fbe-a8ec-14b43ef257c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

