### PR TITLE
docs: initialize Obsidian project memory and Phase 1 repository analysis

### DIFF
--- a/obsidian-smartmoons/00_PROJECT_OVERVIEW.md
+++ b/obsidian-smartmoons/00_PROJECT_OVERVIEW.md
@@ -1,0 +1,17 @@
+# SmartMoons Projektüberblick
+
+## Zielbild (Visual Production)
+SmartMoons wird von einem klassischen Browsergame-Layout zu einem modernen 2.5D-Space-Strategy-Erlebnis transformiert.
+
+## Aktueller Ist-Stand (Phase 1 Analyse)
+- Legacy-2Moons-basierte PHP-Anwendung mit Front-Controllern `index.php` (LOGIN) und `game.php` (INGAME).
+- Twig als aktives Template-System, inkl. moderner Layout-Dateien (`layout.modern.twig`, `layout.responsive.twig`).
+- Keine dedizierte `api.php` vorhanden; AJAX aktuell über Seiten-Controller/`mode`/`ajax`-Flags verteilt.
+- Kein `public/`-Webroot vorhanden, Assets liegen aktuell unter `styles/` und `scripts/`.
+- Keine Phaser-3-Integration im aktuellen Codebestand.
+
+## Leitprinzipien der Migration
+1. API-first Kern einziehen, ohne bestehende Spiellogik zu brechen.
+2. Phaser als primäre Rendering-Schicht schrittweise etablieren.
+3. Legacy-Twig-Seiten zunächst als funktionale Fallbacks erhalten.
+4. Modular in Etappen migrieren (Planet -> Gebäude/Forschung/Werft/Defense -> Galaxy -> UX/Android).

--- a/obsidian-smartmoons/01_ARCHITECTURE.md
+++ b/obsidian-smartmoons/01_ARCHITECTURE.md
@@ -1,0 +1,24 @@
+# Architektur (Ist-Zustand)
+
+## Entry Points
+- `index.php`: Login-Router (`MODE=LOGIN`), dynamische Page-Klasse unter `includes/pages/login/`.
+- `game.php`: Ingame-Router (`MODE=INGAME`), dynamische Page-Klasse unter `includes/pages/game/`.
+- `admin.php`: Admin-Bereich (separate Routing-/Page-Struktur).
+
+## Bootstrap
+- `includes/common.php` initialisiert Composer-Autoload, Fehlerbehandlung, DB/Config/Session/User/Planet-Kontext.
+- Session- und User-Validierung erfolgt zentral in `common.php` für Ingame/Admin/Cron.
+
+## Rendering
+- Twig-Engine wird in `includes/classes/class.template.php` konfiguriert (Loader, Filter, Funktionen, Cache).
+- Game/Login Abstract Pages rendern `.twig` direkt (mit `.tpl`-Kompatibilitätsersetzung).
+
+## Frontend
+- Aktuell überwiegend klassisches JS/jQuery (`scripts/game/*`, `scripts/base/*`).
+- CSS-Monolith vorhanden (`styles/theme/smartmoons.css`) plus resource-basierte Styles.
+- Template-Basis unter `styles/templates/{game,login,adm}`.
+
+## Zielarchitektur (Soll)
+- Neuer API-Layer (`/api.php?action=...`) als primärer Datenzugriff.
+- Neuer Phaser-Client unter künftigem `public/js/game/`.
+- Asset-Pipeline unter `public/assets/game/` (Sprites, UI, Partikel, Hintergründe, Audio).

--- a/obsidian-smartmoons/02_PHASER_FRONTEND_PLAN.md
+++ b/obsidian-smartmoons/02_PHASER_FRONTEND_PLAN.md
@@ -1,0 +1,29 @@
+# Phaser Frontend Plan
+
+## Analyse-Ergebnis
+- Im aktuellen Repository existiert noch keine Phaser-Bibliothek und kein Scene-System.
+
+## Ziel-Scenes
+1. BootScene
+2. PreloadScene
+3. LoginBackgroundScene
+4. PlanetScene
+5. BuildingScene
+6. ResearchScene
+7. ShipyardScene
+8. DefenseScene
+9. GalaxyScene
+10. FleetScene
+11. MessageScene
+12. RankingScene
+
+## Einführungsstrategie
+- Schritt 1: Basis-Ordnerstruktur anlegen (`public/js/game`, `public/assets/game`).
+- Schritt 2: `BootScene` + `PreloadScene` + Login-Hintergrund in bestehende Login-Seite einbetten.
+- Schritt 3: PlanetScene als erster spielbarer Hub mit Orbit-Layern, Parallax, HUD-Overlay.
+- Schritt 4: Weitere Game-Systeme als einzelne Scene-Module anbinden.
+
+## Tech-Standards
+- Asset-Manifest (JSON) + versionsbasierter Cache-Buster.
+- Kamera-Zoom/Pan als Standardsteuerung.
+- Depth-Sorting und Partikel als Basiskomponenten.

--- a/obsidian-smartmoons/03_API_CONTRACTS.md
+++ b/obsidian-smartmoons/03_API_CONTRACTS.md
@@ -1,0 +1,39 @@
+# API Contracts (Planung)
+
+## Ist-Zustand
+- Kein zentraler `/api.php` Endpoint.
+- JSON-Antworten werden aktuell punktuell in einzelnen Page-Controllern ausgegeben.
+
+## Geplante Basisstruktur
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null,
+  "meta": {"timestamp": 0, "request_id": ""}
+}
+```
+
+## Priorisierte Endpoints
+- GET `api.php?action=game_state`
+- GET `api.php?action=planet_state`
+- GET `api.php?action=resources`
+- GET `api.php?action=buildings`
+- POST `api.php?action=build_building`
+- GET `api.php?action=research`
+- POST `api.php?action=start_research`
+- GET `api.php?action=shipyard`
+- POST `api.php?action=build_ships`
+- GET `api.php?action=defense`
+- POST `api.php?action=build_defense`
+- GET `api.php?action=galaxy`
+- GET `api.php?action=fleets`
+- POST `api.php?action=send_fleet`
+- GET `api.php?action=messages`
+- GET `api.php?action=ranking`
+
+## Security-Regeln
+- Session/Auth serverseitig prüfen.
+- Rechte-/Feature-Checks zentralisieren.
+- Eingaben strikt validieren (Typ, Range, Ownership).
+- Niemals spielrelevante Berechnungen clientseitig autoritativ akzeptieren.

--- a/obsidian-smartmoons/04_DATABASE_NOTES.md
+++ b/obsidian-smartmoons/04_DATABASE_NOTES.md
@@ -1,0 +1,15 @@
+# Database Notes
+
+## Ist-Zustand
+- MySQL via `includes/classes/Database.class.php`.
+- DB-Version-Prüfung in `includes/common.php` gegen `DB_VERSION_REQUIRED`.
+- Legacy-Kompatibilität (`Database_BC`) für alten Admin-Pfad vorhanden.
+
+## Migrationsprinzip
+- Keine großen Schema-Brüche in einer Etappe.
+- Für API-Layer: zuerst Read-Endpunkte auf bestehende Tabellen.
+- Danach Write-Endpunkte mit transaktionaler Absicherung.
+
+## ToDo
+- Tabellenfelder für Gebäude/Forschung/Werft/Defense in API DTOs mappen.
+- Einheitliches Fehler- und Konfliktmodell definieren (z.B. Bauqueue voll, Ressourcen fehlen).

--- a/obsidian-smartmoons/05_UI_UX_DESIGN_SYSTEM.md
+++ b/obsidian-smartmoons/05_UI_UX_DESIGN_SYSTEM.md
@@ -1,0 +1,18 @@
+# UI/UX Design System
+
+## Visual Direction
+- Dark Sci-Fi, Neon/Hologram, Glass Panels, weiche Motion.
+- Minimaler Text, hohe visuelle Informationsdichte.
+
+## UI-Grundlagen
+- HUD zuerst: Ressourcen, Flottenstatus, Alerts, Quick Actions.
+- Kontext-Panels statt voller Seitenwechsel.
+- Touch-taugliche Targets (mobile-first Interaktionsflächen).
+
+## Component Backlog
+- Primary/Secondary Buttons (Glow States)
+- HUD Resource Chips
+- Modular Overlay Panels
+- Orbit Slot Indicators
+- Notification Toasts
+- Context Radial Menus (Planet/Galaxy)

--- a/obsidian-smartmoons/06_MIGRATION_LOG.md
+++ b/obsidian-smartmoons/06_MIGRATION_LOG.md
@@ -1,0 +1,7 @@
+# Migration Log
+
+## 2026-05-13 — Phase 1 gestartet
+- Korrektes Repository analysiert (Routing, Bootstrap, Templates, Assets, JS-Struktur).
+- Festgestellt: Twig produktiv aktiv, kein Phaser, kein zentrales api.php.
+- Obsidian-Projektgedächtnis initial angelegt (00-08 Pflichtdateien).
+- Architektur-, API- und Frontend-Migrationspfad dokumentiert.

--- a/obsidian-smartmoons/07_OPEN_TASKS.md
+++ b/obsidian-smartmoons/07_OPEN_TASKS.md
@@ -1,0 +1,16 @@
+# Open Tasks
+
+## Phase 2 Vorbereitung
+- [ ] `public/assets/game/` Struktur anlegen
+- [ ] `public/js/game/` Struktur anlegen
+- [ ] Asset-Manifest definieren (`assets-manifest.json`)
+- [ ] Erste echte PNG/Sprite-Asset-Serie erstellen (Planet, Orbit, Sterne, Nebel, UI)
+- [ ] Phaser Grundintegration (Boot/Preload/LoginBackground)
+- [ ] Login Twig um Phaser Canvas Layer erweitern
+- [ ] PlanetScene MVP mit Kamera + Parallax + Interaktion
+
+## API Vorbereitung
+- [ ] `api.php` Router anlegen
+- [ ] Standard-JSON Response-Helper
+- [ ] Session/Auth Middleware für API
+- [ ] Read-Endpoints game_state/planet_state/resources/buildings

--- a/obsidian-smartmoons/08_ANDROID_API_PREPARATION.md
+++ b/obsidian-smartmoons/08_ANDROID_API_PREPARATION.md
@@ -1,0 +1,15 @@
+# Android/API Vorbereitung
+
+## Ziel
+Web-App so strukturieren, dass Flutter/WebView oder nativer API-Client später ohne Logik-Duplikation anschließbar ist.
+
+## Anforderungen
+- Stabile, versionierbare API-Verträge.
+- Fehlercodes maschinenlesbar (`error.code`, `error.message`).
+- Zeit-/Queue-Informationen in UTC + server timestamp.
+- Konsistente IDs und Enum-Werte für Client-Caching.
+
+## Nächste Schritte
+1. API v1 Namespace-Konvention festlegen (`action` oder `/api/v1/*`).
+2. Auth-Strategie für spätere native Clients definieren.
+3. Polling/WebSocket-Strategie für Flotten- und Bauzeiten planen.


### PR DESCRIPTION
### Motivation
- Capture a persistent project memory so all migration steps and design decisions are recorded before any code changes. 
- Establish a clear, low-risk Phase‑1 analysis of the existing repository to avoid reusing wrong assumptions from older projects. 
- Prepare an API-first + Phaser migration path and a concrete Phase‑2 task backlog so the visual production can start in a controlled, iterative way.

### Description
- Added an `/obsidian-smartmoons/` project memory with the required files: `00_PROJECT_OVERVIEW.md` through `08_ANDROID_API_PREPARATION.md` documenting goals and constraints. 
- Documented current architecture and bootstrap behavior including entry points (`index.php`, `game.php`), Twig usage (`includes/classes/class.template.php`) and request/session bootstrap (`includes/common.php`), and noted the absence of a central `api.php` and Phaser integration. 
- Created a Phaser frontend plan listing target Scenes, folder layout (`public/js/game`, `public/assets/game`) and asset/manifest strategy, plus a UI/UX design system and migration log. 
- Defined API contracts and a prioritized endpoint list with a standard `success/data/error/meta` JSON schema and security rules, and added a Phase‑2 open tasks backlog for API and asset work.

### Testing
- Ran repository discovery commands (`rg --files`, `find`) to enumerate files and directories and they completed successfully. 
- Executed targeted searches (`rg -n "Twig|api.php|phaser|json_encode|AJAX_REQUEST"`) to verify usage patterns and outputs matched the documented observations. 
- Verified directory listings for `includes`, `styles`, and `scripts` with `find` and confirmed the layout used in the architecture notes. 
- Confirmed presence of the new `/obsidian-smartmoons/` files via workspace listing commands and validation checks which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a8c3504832cb9918643a1d804a8)