### PR TITLE
Add missing install Twig header/footer templates

### DIFF
--- a/styles/templates/install/ins_footer.twig
+++ b/styles/templates/install/ins_footer.twig
@@ -1,0 +1,4 @@
+    </table>
+</div>
+</body>
+</html>

--- a/styles/templates/install/ins_header.twig
+++ b/styles/templates/install/ins_header.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ lang|default('en') }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title|default('SmartMoons Installer') }}</title>
+    <link rel="stylesheet" href="../styles/resource/css/base/jquery.css">
+    <link rel="stylesheet" href="../styles/resource/css/install/install.css">
+    <script src="../scripts/base/jquery.js"></script>
+</head>
+<body>
+<div id="install">
+    <table>
+        <tr>
+            <th colspan="3">{{ header|default('Installation') }}</th>
+        </tr>


### PR DESCRIPTION
### Motivation
- Installer and error Twig templates referenced `ins_header.twig` and `ins_footer.twig` which were missing, causing Twig `FilesystemLoader` exceptions and preventing installer/upgrade/error pages from rendering.

### Description
- Added `styles/templates/install/ins_header.twig` which provides the HTML head/body and opens the install table, and `styles/templates/install/ins_footer.twig` which closes the table/body/html to restore the expected include structure.

### Testing
- Verified the includes and repository state with `rg 'ins_header|ins_footer' -n styles/templates/install includes install`, inspected the diffs, and created the commit with `git add ... && git commit -m "Fix missing install Twig layout templates"`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f08a4fb4832cbb30d1f57e5312fd)