### PR TITLE
Use namespaced install header/footer templates and add header/footer files

### DIFF
--- a/styles/templates/install/error_message_body.twig
+++ b/styles/templates/install/error_message_body.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div class="installcontent">	
@@ -10,4 +10,4 @@
 		</div>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_doupdate.twig
+++ b/styles/templates/install/ins_doupdate.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div id="main" align="left">
@@ -10,4 +10,4 @@
 		</div><br><a href="../index.php"><button style="cursor: pointer;">{{ LNG.upgrade_back }}</button></a>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_footer.twig
+++ b/styles/templates/install/ins_footer.twig
@@ -1,0 +1,4 @@
+    </table>
+</div>
+</body>
+</html>

--- a/styles/templates/install/ins_header.twig
+++ b/styles/templates/install/ins_header.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ lang|default('en') }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title|default('SmartMoons Installer') }}</title>
+    <link rel="stylesheet" href="../styles/resource/css/base/jquery.css">
+    <link rel="stylesheet" href="../styles/resource/css/install/install.css">
+    <script src="../scripts/base/jquery.js"></script>
+</head>
+<body>
+<div id="install">
+    <table>
+        <tr>
+            <th colspan="3">{{ header|default('Installation') }}</th>
+        </tr>

--- a/styles/templates/install/ins_req.twig
+++ b/styles/templates/install/ins_req.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 
 <div class="step-description">
 	<p>{{ LNG.req_desc|raw }}</p>
@@ -106,4 +106,4 @@
 	</form>
 </div>
 {% endif %}
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_step8error.twig
+++ b/styles/templates/install/ins_step8error.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div class="installcontent">
@@ -11,4 +11,4 @@
 		</div>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_upgrade.twig
+++ b/styles/templates/install/ins_upgrade.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div id="lang" align="right">{{ LNG.intro_lang }}: <select id="lang" name="lang" onchange="document.location = '?lang='+$(this).val();"><!-- TODO: Complex html_options - needs manual review --></select></div>
@@ -21,4 +21,4 @@
 	</td>
 </tr>
 {% endif %}
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}


### PR DESCRIPTION
### Motivation

- Consolidate the installer page layout by introducing dedicated header and footer templates for the install flow.
- Update install templates to reference the namespaced include path to ensure consistent template resolution and enable theme/namespace resolution.

### Description

- Added `styles/templates/install/ins_header.twig` which provides the DOCTYPE, `<head>` (meta tags, CSS and JS includes) and the opening install markup and table header.
- Added `styles/templates/install/ins_footer.twig` which closes the table, install container and HTML body.
- Updated install templates to include the namespaced files by replacing `"ins_header.twig"`/`"ins_footer.twig"` with `"@install/ins_header.twig"`/`"@install/ins_footer.twig"` in `error_message_body.twig`, `ins_doupdate.twig`, `ins_req.twig`, `ins_step8error.twig`, and `ins_upgrade.twig`.

### Testing

- Ran a Twig syntax check on the modified templates using a template linter and there were no syntax errors.
- Performed a smoke-render of the affected install pages to verify the new header/footer render and the installer pages load correctly, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f08a4fb4832cbb30d1f57e5312fd)