### PR TITLE
Add DB version constant and extract install header/footer with namespaced Twig includes

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -56,6 +56,9 @@ if(!defined('CACHE_PATH')) {
 
 define('COMBAT_ENGINE'				, 'xnova');
 
+// Required database schema version used by install/upgrade checks.
+define('DB_VERSION_REQUIRED'      , 12);
+
 // For Fatal Errors!
 define('DEFAULT_LANG'				, 'de');
 

--- a/styles/templates/install/error_message_body.twig
+++ b/styles/templates/install/error_message_body.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div class="installcontent">	
@@ -10,4 +10,4 @@
 		</div>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_doupdate.twig
+++ b/styles/templates/install/ins_doupdate.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div id="main" align="left">
@@ -10,4 +10,4 @@
 		</div><br><a href="../index.php"><button style="cursor: pointer;">{{ LNG.upgrade_back }}</button></a>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_footer.twig
+++ b/styles/templates/install/ins_footer.twig
@@ -1,0 +1,4 @@
+    </table>
+</div>
+</body>
+</html>

--- a/styles/templates/install/ins_header.twig
+++ b/styles/templates/install/ins_header.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ lang|default('en') }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title|default('SmartMoons Installer') }}</title>
+    <link rel="stylesheet" href="../styles/resource/css/base/jquery.css">
+    <link rel="stylesheet" href="../styles/resource/css/install/install.css">
+    <script src="../scripts/base/jquery.js"></script>
+</head>
+<body>
+<div id="install">
+    <table>
+        <tr>
+            <th colspan="3">{{ header|default('Installation') }}</th>
+        </tr>

--- a/styles/templates/install/ins_req.twig
+++ b/styles/templates/install/ins_req.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 
 <div class="step-description">
 	<p>{{ LNG.req_desc|raw }}</p>
@@ -106,4 +106,4 @@
 	</form>
 </div>
 {% endif %}
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_step8error.twig
+++ b/styles/templates/install/ins_step8error.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div class="installcontent">
@@ -11,4 +11,4 @@
 		</div>
 	</td>
 </tr>
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}

--- a/styles/templates/install/ins_upgrade.twig
+++ b/styles/templates/install/ins_upgrade.twig
@@ -1,4 +1,4 @@
-{% include "ins_header.twig" %}
+{% include "@install/ins_header.twig" %}
 <tr>
 	<td colspan="2">
 		<div id="lang" align="right">{{ LNG.intro_lang }}: <select id="lang" name="lang" onchange="document.location = '?lang='+$(this).val();"><!-- TODO: Complex html_options - needs manual review --></select></div>
@@ -21,4 +21,4 @@
 	</td>
 </tr>
 {% endif %}
-{% include "ins_footer.twig" %}
+{% include "@install/ins_footer.twig" %}


### PR DESCRIPTION
### Motivation
- Introduce a required database schema version used by install/upgrade checks to ensure upgrades validate against a target schema.
- Modernize and centralize the install UI by extracting a common header and footer for install templates and switching includes to the namespaced install templates.

### Description
- Define `DB_VERSION_REQUIRED` = 12 in `includes/constants.php` for installer/upgrade checks.
- Add new `styles/templates/install/ins_header.twig` to provide the common HTML head, CSS/JS links and opening markup, and `styles/templates/install/ins_footer.twig` to provide closing markup.
- Update install templates to use namespaced includes (for example replace `{% include "ins_header.twig" %}` with `{% include "@install/ins_header.twig" %}` and similarly for the footer) in `error_message_body.twig`, `ins_doupdate.twig`, `ins_req.twig`, `ins_step8error.twig`, and `ins_upgrade.twig`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f08a4fb4832cbb30d1f57e5312fd)